### PR TITLE
Deps: Drop request in favour of native fetch

### DIFF
--- a/OpenDotaAPI.js
+++ b/OpenDotaAPI.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const request = require("request");
 const querystring = require("querystring");
 
 // Import cache as a dynamic import since it's an ESM module
@@ -13,33 +12,42 @@ const SEVEN_DAYS = 7 * 24 * 60 * 60;
 
 function API() {
   const prefix = "https://api.opendota.com/api/";
-  function getRequest(url, params) {
+  // Resolves [] rather than throwing on any failure: a poll that misses one player
+  // should not take down the whole run.
+  async function getRequest(url, params) {
     params = params ? params : {};
 
     const requestUrl = `${prefix}${url}?${querystring.stringify(params)}`;
 
-    return new Promise((resolve, reject) => {
-      request({ url: requestUrl, timeout: 10000 }, (err, response, body) => {
-        if (err) {
-          console.error(`request error ${url}:`);
-          console.error(err);
-          if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
-            console.error(`Request timed out after 10 seconds for ${url}`);
-          }
-          return resolve([]);
-        }
-
-        let data;
-        try {
-          data = JSON.parse(body);
-        } catch (parseError) {
-          console.error(`Failed to parse JSON response: ${parseError.message}. Response preview: ${body.substring(0, 200)}`);
-          return resolve([]);
-        }
-
-        resolve(data);
+    let body;
+    try {
+      const response = await fetch(requestUrl, {
+        signal: AbortSignal.timeout(10000),
       });
-    });
+
+      if (!response.ok) {
+        console.error(`request error ${url}: HTTP ${response.status}`);
+        return [];
+      }
+
+      body = await response.text();
+    } catch (err) {
+      console.error(`request error ${url}:`);
+      console.error(err);
+      if (err.name === "TimeoutError") {
+        console.error(`Request timed out after 10 seconds for ${url}`);
+      }
+      return [];
+    }
+
+    try {
+      return JSON.parse(body);
+    } catch (parseError) {
+      console.error(
+        `Failed to parse JSON response: ${parseError.message}. Response preview: ${body.substring(0, 200)}`,
+      );
+      return [];
+    }
   }
 
   async function getMatch(matchID) {

--- a/lib/Discord.js
+++ b/lib/Discord.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const request = require("request");
-
 module.exports = function () {
   let channels = {};
   let userAgent = "";
@@ -13,61 +11,32 @@ module.exports = function () {
     apikey = data.apikey;
   }
 
-  function sendMessage(message, channel) {
-    return new Promise((resolve, reject) => {
-      if (!message) {
-        message = "";
-      }
-      if (!channel) {
-        channel = "default";
-      }
+  async function sendEmbed(embed, channel, components) {
+    if (!channel) {
+      channel = "default";
+    }
 
-      if (!(channel in channels)) {
-        console.error(`Unknown channel: ${channel}`);
-        return reject();
-      }
+    if (!(channel in channels)) {
+      console.error(`Unknown channel: ${channel}`);
+      throw new Error(`Unknown channel: ${channel}`);
+    }
 
-      request.post(
+    const payload = {
+      embeds: [embed],
+      allow_mentions: { parse: [] },
+    };
+    if (components) {
+      payload.components = components;
+    }
+
+    let response;
+    let body;
+    let err;
+    try {
+      response = await fetch(
+        `https://discordapp.com/api/channels/${channels[channel]}/messages`,
         {
-          url: `https://discordapp.com/api/channels/${channels[channel]}/messages`,
-          headers: {
-            "User-Agent": userAgent,
-            Authorization: `Bot ${apikey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            content: message,
-          }),
-        },
-        function (err, response, body) {
-          resolve();
-        },
-      );
-    });
-  }
-
-  function sendEmbed(embed, channel, components) {
-    return new Promise((resolve, reject) => {
-      if (!channel) {
-        channel = "default";
-      }
-
-      if (!(channel in channels)) {
-        console.error(`Unknown channel: ${channel}`);
-        return reject();
-      }
-
-      const payload = {
-        embeds: [embed],
-        allow_mentions: { parse: [] },
-      };
-      if (components) {
-        payload.components = components;
-      }
-
-      request.post(
-        {
-          url: `https://discordapp.com/api/channels/${channels[channel]}/messages`,
+          method: "POST",
           headers: {
             "User-Agent": userAgent,
             Authorization: `Bot ${apikey}`,
@@ -75,22 +44,24 @@ module.exports = function () {
           },
           body: JSON.stringify(payload),
         },
-        function (err, response, body) {
-          const hadError = !!err || response.statusCode !== 200;
-          if (hadError) {
-            console.error("Error sending discord message:");
-            console.error({
-              embed,
-              err,
-              statusCode: response?.statusCode,
-              body,
-            });
-          }
-
-          resolve({ error: hadError });
-        },
       );
-    });
+      body = await response.text();
+    } catch (fetchError) {
+      err = fetchError;
+    }
+
+    const hadError = !!err || response.status !== 200;
+    if (hadError) {
+      console.error("Error sending discord message:");
+      console.error({
+        embed,
+        err,
+        statusCode: response?.status,
+        body,
+      });
+    }
+
+    return { error: hadError };
   }
 
   async function sendInteractionResponse(
@@ -122,7 +93,6 @@ module.exports = function () {
   }
 
   this.init = init.bind(this);
-  this.sendMessage = sendMessage.bind(this);
   this.sendEmbed = sendEmbed.bind(this);
   this.sendInteractionResponse = sendInteractionResponse.bind(this);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "@aws-sdk/client-scheduler": "^3.700.0",
         "@aws-sdk/lib-dynamodb": "^3.700.0",
         "cheerio": "^0.22.0",
-        "dotaconstants": "^10.8.0",
-        "request": "^2.88.0"
+        "dotaconstants": "^10.8.0"
       },
       "devDependencies": {
         "esbuild": "^0.28.1",
@@ -1105,51 +1104,11 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
@@ -1376,30 +1335,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1415,12 +1350,6 @@
     "node_modules/c0rbot-cdk": {
       "resolved": "cdk",
       "link": true
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/cheerio": {
       "version": "0.22.0",
@@ -1449,29 +1378,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/constructs": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
       "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1499,27 +1410,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -1572,16 +1462,6 @@
       "integrity": "sha512-4imDHLtqBg4abJ2Q/t2Kac/rM5kB5mCBF1lXaUDFtmoJ+TDku8TZ+R8ilU5l7xWpLZBEEYAe+u40CWxku9iFWA==",
       "license": "MIT"
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -1630,88 +1510,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -1726,77 +1524,11 @@
         "readable-stream": "^3.1.1"
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/lodash.assignin": {
       "version": "4.2.0",
@@ -1878,27 +1610,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -1917,25 +1628,10 @@
         "boolbase": "~1.0.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
     },
     "node_modules/prettier": {
@@ -1954,36 +1650,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -1993,38 +1659,6 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       },
       "engines": {
         "node": ">= 6"
@@ -2050,37 +1684,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2088,19 +1691,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/ts-node": {
@@ -2153,24 +1743,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
-    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -2192,30 +1764,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -2223,20 +1776,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "@aws-sdk/client-scheduler": "^3.700.0",
     "@aws-sdk/lib-dynamodb": "^3.700.0",
     "cheerio": "^0.22.0",
-    "dotaconstants": "^10.8.0",
-    "request": "^2.88.0"
+    "dotaconstants": "^10.8.0"
   },
   "devDependencies": {
     "esbuild": "^0.28.1",

--- a/utils.js
+++ b/utils.js
@@ -6,22 +6,36 @@ const {
   GetCommand,
   PutCommand,
 } = require("@aws-sdk/lib-dynamodb");
-const request = require("request");
 
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
-module.exports.simpleGet = async (url, options = {}) => {
-  return new Promise((resolve, reject) => {
-    request({ url, ...options }, (err, response, body) => {
-      if (err) {
-        console.error(`request error ${url}:`);
-        console.error(err);
-      }
+// `request` sent no User-Agent and every scrape target accepted it. `fetch` sends
+// `node`, so name ourselves rather than let an origin decide what that means.
+const USER_AGENT = "c0rbot/1.0 (+https://github.com/coreymaher/c0rbot)";
 
-      resolve(body);
+// Resolves the response body, or `undefined` on any failure -- callers treat a falsy
+// result as a transient error and skip the run.
+module.exports.simpleGet = async (url, { qs, headers, timeout } = {}) => {
+  const target = qs ? `${url}?${new URLSearchParams(qs)}` : url;
+
+  try {
+    const response = await fetch(target, {
+      headers: { "User-Agent": USER_AGENT, ...headers },
+      signal: timeout ? AbortSignal.timeout(timeout) : undefined,
     });
-  });
+
+    if (!response.ok) {
+      console.error(`request error ${url}: HTTP ${response.status}`);
+      return undefined;
+    }
+
+    return await response.text();
+  } catch (err) {
+    console.error(`request error ${url}:`);
+    console.error(err);
+    return undefined;
+  }
 };
 
 module.exports.loadFeedData = async (key) => {


### PR DESCRIPTION
## Motivation

`request` was deprecated in 2020 and gets no updates. Three files still used it — `utils.js`, `lib/Discord.js`, `OpenDotaAPI.js` — and they sit on the shared path, so every Lambda paid for it. Newer code in the repo (`lib/LLMClient.mjs`, `lib/DeadlockAPI.mjs`, `lib/OpenDotaAPI.mjs`, `Discord.sendInteractionResponse`) already uses `fetch`.

## Changes

- **`utils.js`** — `simpleGet` over `fetch`. `qs` → `URLSearchParams`, `timeout` → `AbortSignal.timeout`. Adds a `!response.ok` guard so a 500's HTML body never reaches `JSON.parse`/`cheerio.load`, and an explicit `User-Agent`: Node's `fetch` announces itself as `node`, where `request` sent no UA at all.
- **`lib/Discord.js`** — `sendEmbed` over `fetch`, same `{ error: status !== 200 }` contract and log shape. Dropped `sendMessage`, which had no callers. Unknown-channel now rejects with a named `Error` rather than bare `undefined`.
- **`OpenDotaAPI.js`** — `getRequest` over `fetch` with a 10s `AbortSignal`, keeping the resolve-`[]`-on-anything-bad behaviour.
- **`package.json`** — `request` removed.

No call site signatures changed, so no handler needed editing.

## Impact

| function | before | after |
| --- | --- | --- |
| `steamUpdates` | 1.3 mb | **16 kb** |
| `deadlockMatches` | 1.3 mb | 28 kb |
| `deadlockAnalyst` | 1.4 mb | 76 kb |
| `openDotaMatches` | 1.4 mb | 160 kb |
| `noMansSkyPatches` | 1.8 mb | 528 kb |
| `deadlockPatches` | 1.8 mb | 528 kb |
| `dotaAnalyst` | 3.8 mb | 2.5 mb |
| `discordWebhookHandler` | 8 kb | 8 kb |

`steamUpdates` was 12 kb of our code and 1306 kb of `request`'s tree across 45 packages. What remains in the larger three is `cheerio` (~500 kb) and `dotaconstants` (~2.4 mb).

`npm audit` goes from 10 advisories to 5, both criticals gone; the remainder are all `cheerio@0.22`.

## Validation

- **Live body diff.** Captured all four scrape targets with `request` first, then re-fetched with the new `simpleGet`. Only differences are time-varying content — RSS `pubDate`, CSP nonces, Steam vote counts. No UA-driven behaviour change.
- **Smoke tests, all passing:** the four targets parsed the way the handlers parse them (Steam `qs` → 10 events, RSS → guid+title, NMS → PC release cell, Deadlock → 371 matches); `simpleGet` failure paths (HTTP 500, timeout, unresolvable host → `undefined`; 200 → body string); `sendEmbed` payload/headers/method against a local server, plus `{ error: true }` on 500 and on network failure, and unknown-channel still rejecting; `OpenDotaAPI` against the live API including a 400 → `[]`.
- **`cdk diff`:** asset-hash churn on the 7 affected functions, nothing else — no resource, IAM, schedule or environment changes.

## Not yet done

Not deployed. Post-merge, invoke `c0rbot-steamUpdates` (clearest signal — `simpleGet` + `sendEmbed` + a feed write), then `noMansSkyPatches`, `deadlockPatches`, `deadlockMatches`, `openDotaMatches`. A steady-state feed posts nothing, so confirm via logs or clear a `feeds-dev` row to force a post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)