### PR TITLE
OpenDotaMatches: Replace the promise chains with await

### DIFF
--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -23,133 +23,120 @@ function formatNumber(number) {
   return number >= 1000 ? (number / 1000).toFixed(1) + "k" : number;
 }
 
-async function loadDBUsers(data) {
-  try {
-    const scanParams = {
-      TableName: process.env.table,
-    };
+async function loadDBUsers() {
+  const scanParams = {
+    TableName: process.env.table,
+  };
 
+  try {
     const result = await docClient.send(new ScanCommand(scanParams));
-    data.dbUsers = result.Items;
-    return data;
+    return result.Items;
   } catch (err) {
     console.error("DynamoDB.get error:");
     console.error(err);
-    console.error({ TableName: process.env.table });
-    return data;
+    console.error(scanParams);
+    return [];
   }
 }
 
-async function loadConfig(data) {
-  try {
-    const scanParams = {
-      TableName: tables.config,
-      FilterExpression: "ConfigScope = :s",
-      ExpressionAttributeValues: {
-        ":s": "OpenDotaMatches",
-      },
-    };
+async function loadConfig() {
+  const scanParams = {
+    TableName: tables.config,
+    FilterExpression: "ConfigScope = :s",
+    ExpressionAttributeValues: {
+      ":s": "OpenDotaMatches",
+    },
+  };
 
+  try {
     const result = await docClient.send(new ScanCommand(scanParams));
-    data.config = result.Items.reduce((config, item) => {
+    return result.Items.reduce((config, item) => {
       config[item.Key] = item.Value;
       return config;
     }, {});
-
-    return data;
   } catch (err) {
     console.error("DynamoDB.get error:");
     console.error(err);
-    console.error({
-      TableName: tables.config,
-      FilterExpression: "ConfigScope = :s",
-      ExpressionAttributeValues: { ":s": "OpenDotaMatches" },
-    });
-    return data;
+    console.error(scanParams);
+    return {};
   }
 }
 
-function loadRecentMatches(data) {
-  console.log(`Checking matches for ${data.dbUsers.length} users`);
-  const userPromises = data.dbUsers.map((user) => {
-    // Only this stage is guarded. Later ones abort the run instead, which is safe:
-    // updateDB never runs, so the next poll picks the same matches back up.
-    return openDotaAPI
-      .getRecentMatches(user.steamID)
-      .catch((err) => {
+async function collectNewMatches(dbUsers) {
+  console.log(`Checking matches for ${dbUsers.length} users`);
+
+  const users = {};
+  const matches = {};
+
+  await Promise.all(
+    dbUsers.map(async (user) => {
+      let recentMatches;
+      // Only this stage is guarded. Later ones abort the run instead, which is safe:
+      // updateDB never runs, so the next poll picks the same matches back up.
+      try {
+        recentMatches = await openDotaAPI.getRecentMatches(user.steamID);
+      } catch (err) {
         console.error(`Recent matches failed for ${user.steamID}:`, err);
-        return [];
-      })
-      .then((matches) => {
+        recentMatches = [];
+      }
+
+      console.log(
+        `User ${user.steamID}: got ${recentMatches.length} recent matches, last notified ${user.last_matchID}`,
+      );
+
+      // Match IDs increment, so a greater ID is a newer match.
+      const newMatches = recentMatches.filter(
+        (match) => match.match_id > user.last_matchID,
+      );
+      console.log(
+        `User ${user.steamID}: found ${newMatches.length} new matches`,
+      );
+
+      if (newMatches.length === 0) {
+        return;
+      }
+
+      newMatches.forEach((match) => {
+        matches[match.match_id] = {};
         console.log(
-          `User ${user.steamID}: got ${matches.length} recent matches, last notified ${user.last_matchID}`,
+          `New match queued: ${match.match_id} for user ${user.steamID}`,
         );
-
-        // Match IDs increment, so a greater ID is a newer match.
-        const newMatches = matches.filter(
-          (match) => match.match_id > user.last_matchID,
-        );
-        console.log(
-          `User ${user.steamID}: found ${newMatches.length} new matches`,
-        );
-
-        if (newMatches.length > 0) {
-          newMatches.forEach((match) => {
-            data.matches[match.match_id] = {};
-            console.log(
-              `New match queued: ${match.match_id} for user ${user.steamID}`,
-            );
-          });
-
-          const sortedMatchIDs = newMatches
-            .map((match) => match.match_id)
-            .sort((a, b) => a - b);
-
-          data.users[user.steamID] = {
-            matches: sortedMatchIDs,
-          };
-        }
-
-        return Promise.resolve();
       });
-  });
 
-  return Promise.all(userPromises).then(() => {
-    console.log(
-      `Found ${Object.keys(data.matches).length} new matches to process`,
-    );
-    return Promise.resolve(data);
-  });
+      users[user.steamID] = {
+        matches: newMatches
+          .map((match) => match.match_id)
+          .sort((a, b) => a - b),
+      };
+    }),
+  );
+
+  console.log(`Found ${Object.keys(matches).length} new matches to process`);
+
+  return { users, matches };
 }
 
-function loadPlayers(data) {
-  const userPromises = Object.keys(data.users).map((steamID) => {
-    return openDotaAPI.getPlayer(steamID).then((result) => {
-      data.users[steamID] = Object.assign(result, data.users[steamID]);
-      return Promise.resolve(data);
-    });
-  });
-
-  return Promise.all(userPromises).then(() => {
-    return Promise.resolve(data);
-  });
+async function loadPlayers(users) {
+  await Promise.all(
+    Object.keys(users).map(async (steamID) => {
+      const player = await openDotaAPI.getPlayer(steamID);
+      users[steamID] = Object.assign(player, users[steamID]);
+    }),
+  );
 }
 
-function loadMatches(data) {
-  const matchDetails = Object.keys(data.matches).map((matchID) => {
-    return openDotaAPI.getMatch(matchID).then((match) => {
-      data.matches[matchID] = match;
+async function loadMatches(users, matches) {
+  await Promise.all(
+    Object.keys(matches).map(async (matchID) => {
+      const match = await openDotaAPI.getMatch(matchID);
+      matches[matchID] = match;
       match.players.forEach((player) => {
-        if (player.account_id in data.users) {
-          data.users[player.account_id].personaname = player.personaname;
+        if (player.account_id in users) {
+          users[player.account_id].personaname = player.personaname;
         }
       });
-    });
-  });
-
-  return Promise.all(matchDetails).then(() => {
-    return Promise.resolve(data);
-  });
+    }),
+  );
 }
 
 function getGameMode(modeID, config) {
@@ -160,192 +147,181 @@ function getGameMode(modeID, config) {
   return DotaConstants.gameModes[modeID];
 }
 
-function sendDiscordMessage(data) {
-  const messagePromises = [];
+function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
+  const dotaPlayer = match.players.find(
+    (player) => player.account_id == steamID,
+  );
 
-  Object.keys(data.users).forEach((steamID) => {
-    const user = data.users[steamID];
+  const skill = DotaConstants.skillIDs[match.skill];
+  const lobby = DotaConstants.lobbyTypes[match.lobby_type];
+  const gameMode = getGameMode(match.game_mode, config);
+  const hero = DotaConstants.heroes[dotaPlayer.hero_id];
+  const isRadiant = dotaPlayer.player_slot < 128;
+  const result = match.radiant_win == isRadiant ? "won" : "lost";
+  const heroDamage = formatNumber(dotaPlayer.hero_damage);
+  const towerDamage = formatNumber(dotaPlayer.tower_damage);
+  const heroHealing = formatNumber(dotaPlayer.hero_healing);
+  const MMRs = match.players
+    .map((player) => {
+      return player.solo_competitive_rank;
+    })
+    .filter((rank) => {
+      return rank;
+    });
+  const rankTiers = match.players
+    .map((player) => {
+      return player.rank_tier;
+    })
+    .filter((rank) => {
+      return rank;
+    });
+  const durationHours = Math.floor(match.duration / 3600);
+  const durationMinutes = Math.floor((match.duration % 3600) / 60);
+  const durationSeconds = Math.floor(match.duration % 60);
+  let duration = "";
+  if (durationHours > 0) {
+    duration += `${durationHours}h `;
+  }
+  duration += `${durationMinutes}m ${durationSeconds}s`;
+
+  const thumbnail_url = `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`;
+
+  let description = `${user.personaname} ${result} a `;
+  if (skill) {
+    description += `${skill} skill `;
+  }
+  if (lobby) {
+    description += `${lobby} `;
+  }
+  description += `${gameMode} match as ${hero.name}`;
+  const embed = {
+    author: {
+      name: user.personaname,
+      icon_url: user.profile.avatar,
+    },
+    description: description,
+    fields: [
+      {
+        name: "k / d / a",
+        value: `${dotaPlayer.kills} / ${dotaPlayer.deaths} / ${dotaPlayer.assists}`,
+        inline: true,
+      },
+      {
+        name: "gpm / xpm",
+        value: `${dotaPlayer.gold_per_min} / ${dotaPlayer.xp_per_min}`,
+        inline: true,
+      },
+      {
+        name: "hd / td / hh",
+        value: `${heroDamage} / ${towerDamage} / ${heroHealing}`,
+        inline: true,
+      },
+      { name: "duration", value: duration, inline: true },
+    ],
+    thumbnail: {
+      url: thumbnail_url,
+    },
+  };
+
+  if (MMRs.length > 1) {
+    const estimatedMMR =
+      MMRs.reduce((total, rank) => {
+        return (total += parseInt(rank, 10));
+      }, 0) / MMRs.length;
+    embed.fields.push({
+      name: "mmr",
+      value: Math.round(estimatedMMR),
+      inline: true,
+    });
+  }
+
+  if (rankTiers.length > 1) {
+    const totalTierIndex = rankTiers
+      .map((rank) => {
+        return DotaConstants.rankTierValues.indexOf(rank);
+      })
+      .reduce((total, rank) => {
+        return (total += rank);
+      }, 0);
+    const estimatedTierIndex = Math.round(totalTierIndex / rankTiers.length);
+    const estimatedTier = DotaConstants.rankTierValues[estimatedTierIndex];
+    const tier = Math.floor(estimatedTier / 10);
+    const subTier = estimatedTier % 10;
+    embed.fields.push({
+      name: "tier",
+      value: `${DotaConstants.rankTiers[tier]} ${subTier}`,
+      inline: true,
+    });
+  }
+
+  embed.fields.push({
+    name: "more",
+    value: `[dotabuff](https://www.dotabuff.com/matches/${matchID}) | [opendota](https://opendota.com/matches/${matchID})`,
+  });
+
+  const components = [
+    {
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 1,
+          label: "Analyze",
+          custom_id: `ai:${matchID}:${steamID}`,
+        },
+      ],
+    },
+  ];
+
+  return { embed, components };
+}
+
+async function sendDiscordMessages(users, matches, config) {
+  const messages = [];
+
+  Object.keys(users).forEach((steamID) => {
+    const user = users[steamID];
 
     user.matches.forEach((matchID) => {
-      const match = data.matches[matchID];
-      messagePromises.push(
-        createDiscordMessageForMatch(steamID, user, matchID, match),
+      messages.push(
+        createDiscordMessageForMatch(
+          steamID,
+          user,
+          matchID,
+          matches[matchID],
+          config,
+        ),
       );
     });
   });
 
-  function createDiscordMessageForMatch(steamID, user, matchID, match) {
-    const dotaPlayer = match.players.reduce((player, curPlayer) => {
-      let result = player;
-      if (curPlayer.account_id == steamID) {
-        result = curPlayer;
-      }
-
-      return result;
-    });
-
-    const skill = DotaConstants.skillIDs[match.skill];
-    const lobby = DotaConstants.lobbyTypes[match.lobby_type];
-    const gameMode = getGameMode(match.game_mode, data.config);
-    const hero = DotaConstants.heroes[dotaPlayer.hero_id];
-    const isRadiant = dotaPlayer.player_slot < 128;
-    const result = match.radiant_win == isRadiant ? "won" : "lost";
-    const heroDamage = formatNumber(dotaPlayer.hero_damage);
-    const towerDamage = formatNumber(dotaPlayer.tower_damage);
-    const heroHealing = formatNumber(dotaPlayer.hero_healing);
-    const MMRs = match.players
-      .map((player) => {
-        return player.solo_competitive_rank;
-      })
-      .filter((rank) => {
-        return rank;
-      });
-    const rankTiers = match.players
-      .map((player) => {
-        return player.rank_tier;
-      })
-      .filter((rank) => {
-        return rank;
-      });
-    const durationHours = Math.floor(match.duration / 3600);
-    const durationMinutes = Math.floor((match.duration % 3600) / 60);
-    const durationSeconds = Math.floor(match.duration % 60);
-    let duration = "";
-    if (durationHours > 0) {
-      duration += `${durationHours}h `;
-    }
-    duration += `${durationMinutes}m ${durationSeconds}s`;
-
-    const thumbnail_url = `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`;
-
-    let description = `${user.personaname} ${result} a `;
-    if (skill) {
-      description += `${skill} skill `;
-    }
-    if (lobby) {
-      description += `${lobby} `;
-    }
-    description += `${gameMode} match as ${hero.name}`;
-    const embed = {
-      author: {
-        name: user.personaname,
-        icon_url: user.profile.avatar,
-      },
-      description: description,
-      fields: [
-        {
-          name: "k / d / a",
-          value: `${dotaPlayer.kills} / ${dotaPlayer.deaths} / ${dotaPlayer.assists}`,
-          inline: true,
-        },
-        {
-          name: "gpm / xpm",
-          value: `${dotaPlayer.gold_per_min} / ${dotaPlayer.xp_per_min}`,
-          inline: true,
-        },
-        {
-          name: "hd / td / hh",
-          value: `${heroDamage} / ${towerDamage} / ${heroHealing}`,
-          inline: true,
-        },
-        { name: "duration", value: duration, inline: true },
-      ],
-      thumbnail: {
-        url: thumbnail_url,
-      },
-    };
-
-    if (MMRs.length > 1) {
-      const estimatedMMR =
-        MMRs.reduce((total, rank) => {
-          return (total += parseInt(rank, 10));
-        }, 0) / MMRs.length;
-      embed.fields.push({
-        name: "mmr",
-        value: Math.round(estimatedMMR),
-        inline: true,
-      });
-    }
-
-    if (rankTiers.length > 1) {
-      const totalTierIndex = rankTiers
-        .map((rank) => {
-          return DotaConstants.rankTierValues.indexOf(rank);
-        })
-        .reduce((total, rank) => {
-          return (total += rank);
-        }, 0);
-      const estimatedTierIndex = Math.round(totalTierIndex / rankTiers.length);
-      const estimatedTier = DotaConstants.rankTierValues[estimatedTierIndex];
-      const tier = Math.floor(estimatedTier / 10);
-      const subTier = estimatedTier % 10;
-      embed.fields.push({
-        name: "tier",
-        value: `${DotaConstants.rankTiers[tier]} ${subTier}`,
-        inline: true,
-      });
-    }
-
-    embed.fields.push({
-      name: "more",
-      value: `[dotabuff](https://www.dotabuff.com/matches/${matchID}) | [opendota](https://opendota.com/matches/${matchID})`,
-    });
-
-    const components = [
-      {
-        type: 1,
-        components: [
-          {
-            type: 2,
-            style: 1,
-            label: "Analyze",
-            custom_id: `ai:${matchID}:${steamID}`,
-          },
-        ],
-      },
-    ];
-
-    return Promise.resolve({ embed, components });
+  // Sequential on purpose. Promise.all here would post the embeds in whatever order
+  // Discord answers, and would drop the spacing that keeps a burst of matches under
+  // the rate limit.
+  for (const { embed, components } of messages) {
+    await discord.sendEmbed(embed, "results", components);
   }
-
-  return Promise.all(messagePromises)
-    .then((embeds) => {
-      let promise = Promise.resolve();
-
-      embeds.forEach(({ embed, components }) => {
-        promise = promise.then(() => {
-          return discord.sendEmbed(embed, "results", components);
-        });
-      });
-
-      return promise;
-    })
-    .then(() => {
-      return Promise.resolve(data);
-    });
 }
 
-function updateDB(data) {
-  const userPromises = Object.keys(data.users).map((steamID) => {
-    const user = data.users[steamID];
+async function updateDB(users) {
+  await Promise.all(
+    Object.keys(users).map(async (steamID) => {
+      const user = users[steamID];
 
-    const maxMatchID = Math.max(...user.matches);
+      const params = {
+        TableName: process.env.table,
+        Key: {
+          steamID: steamID,
+        },
+        UpdateExpression:
+          "SET last_matchID = :last_matchID, updated_at = :updated_at, dotaname = :dotaname",
+        ExpressionAttributeValues: {
+          ":last_matchID": Math.max(...user.matches),
+          ":updated_at": Date.now(),
+          ":dotaname": user.personaname,
+        },
+      };
 
-    const params = {
-      TableName: process.env.table,
-      Key: {
-        steamID: steamID,
-      },
-      UpdateExpression:
-        "SET last_matchID = :last_matchID, updated_at = :updated_at, dotaname = :dotaname",
-      ExpressionAttributeValues: {
-        ":last_matchID": maxMatchID,
-        ":updated_at": Date.now(),
-        ":dotaname": user.personaname,
-      },
-    };
-
-    return (async () => {
       try {
         await docClient.send(new UpdateCommand(params));
       } catch (err) {
@@ -353,28 +329,19 @@ function updateDB(data) {
         console.error(err);
         console.error(params);
       }
-    })();
-  });
-
-  return Promise.all(userPromises).then(() => {
-    return Promise.resolve(data);
-  });
+    }),
+  );
 }
 
 export async function handler() {
-  const sharedData = {
-    dbUsers: [],
-    config: {},
-    users: {},
-    matches: {},
-  };
+  const dbUsers = await loadDBUsers();
+  const config = await loadConfig();
 
-  return loadDBUsers(sharedData)
-    .then(loadConfig)
-    .then(loadRecentMatches)
-    .then(loadPlayers)
-    .then(loadMatches)
-    .then(sendDiscordMessage)
-    .then(updateDB)
-    .then(() => ({ message: "Done" }));
+  const { users, matches } = await collectNewMatches(dbUsers);
+  await loadPlayers(users);
+  await loadMatches(users, matches);
+  await sendDiscordMessages(users, matches, config);
+  await updateDB(users);
+
+  return { message: "Done" };
 }

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -152,6 +152,18 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
     (player) => player.account_id == steamID,
   );
 
+  // OpenDota reports account_id as null for players who have not exposed their match
+  // data, so a tracked player can be missing from their own match. Skip that match
+  // rather than dereferencing undefined: every embed is built before the first send,
+  // so one throw here would drop the whole run's notifications, and it would throw
+  // again on every retry because updateDB never advances past the match.
+  if (!dotaPlayer) {
+    console.error(
+      `No player ${steamID} in match ${matchID}, skipping notification`,
+    );
+    return null;
+  }
+
   const skill = DotaConstants.skillIDs[match.skill];
   const lobby = DotaConstants.lobbyTypes[match.lobby_type];
   const gameMode = getGameMode(match.game_mode, config);
@@ -283,15 +295,17 @@ async function sendDiscordMessages(users, matches, config) {
     const user = users[steamID];
 
     user.matches.forEach((matchID) => {
-      messages.push(
-        createDiscordMessageForMatch(
-          steamID,
-          user,
-          matchID,
-          matches[matchID],
-          config,
-        ),
+      const message = createDiscordMessageForMatch(
+        steamID,
+        user,
+        matchID,
+        matches[matchID],
+        config,
       );
+
+      if (message) {
+        messages.push(message);
+      }
     });
   });
 


### PR DESCRIPTION
The last handler still written as promise chains — 17 `.then(` and 9 `Promise.resolve`
against zero in every other handler. It predates the rest by years, and the ESM migration
deliberately left its body alone so a changed asset hash meant "moved" and nothing else.

381 → 347 lines. Behaviour is unchanged except for one deliberate fix, called out below.

## Why now

The line count is not the reason. `sendDiscordMessage` encoded **required behaviour in the
shape of a promise chain**:

```js
let promise = Promise.resolve();
embeds.forEach(({ embed, components }) => {
  promise = promise.then(() => discord.sendEmbed(embed, "results", components));
});
```

That is visually indistinguishable from the surrounding ceremony, and the obvious-looking
cleanup — `Promise.all(embeds.map(...))` — breaks it twice: notifications arrive out of
order, and the spacing that keeps a burst under Discord's rate limit disappears. Every
future reader was one plausible edit away from that bug. It is now a `for...of` loop with a
comment saying why.

## What changed

- The shared `data` accumulator is gone. Stages take what they read and return what they
  produce, so each signature declares its own inputs and outputs instead of hiding them in
  a mutated blob. This is what `handlers/DeadlockMatches.mjs` already does.
- `createDiscordMessageForMatch` is synchronous, so it returns an object rather than
  `Promise.resolve(...)`, and the `Promise.all` over already-resolved promises is gone.
- `updateDB` uses `.map(async ...)` instead of `.map()` wrapping an IIFE.
- The `.catch()` wedged mid-chain is now `try`/`catch` around a single `await`.

## The one behaviour change

`createDiscordMessageForMatch` located the tracked player with a seedless `reduce`, which
starts its accumulator at `players[0]`. A match containing no entry for that player
therefore produced an embed with **someone else's hero, K/D/A and rank under the tracked
player's name** — silently, since nothing threw.

Swapping it for `.find` (the readable equivalent) turned that into something worse: `.find`
returns `undefined` and the next line dereferences it. Because every embed is built before
the first send, one such match discards the *entire run's* notifications, and `updateDB`
never advances past it, so every subsequent poll refetches the match and throws in the same
place — a permanent stall rather than a transient failure. OpenDota reports `account_id` as
`null` for players who have not exposed their match data, which is enough to reach it.

`711f47e` guards the lookup and skips the match with an error log. Neither the stall nor
the misattributed embed is worth preserving, so this is a fix rather than parity.

`handlers/DotaAnalyst.mjs` has the same unguarded `.find`-then-dereference, but it is a
per-interaction path where a throw affects only the requester, so it is left for a separate
change.

## Review focus

Four things are load-bearing; the rest of the diff is mechanical.

1. **Discord sends stay sequential and in ascending match order.** Never `Promise.all`.
2. **The three OpenDota stages stay concurrent.** The run has 30s (`cdk/lib/c0rbot-stack.ts`)
   and each call has 10s, so converting these to `for...of await` — the shape
   `DeadlockMatches.mjs` uses — would risk timing out. This is the inverse of the trap
   above, and the two are easy to confuse.
3. **`users` and `matches` stay plain objects, not `Map`s.** Steam32 IDs are integer-like
   keys, so `Object.keys` iterates ascending regardless of which `Promise.all` callback
   resolved first. A `Map` preserves insertion order, which is completion order, which is
   nondeterministic.
4. **Only the `getRecentMatches` call is guarded.** Later stages abort the run, which is
   safe because `updateDB` never runs and the next poll picks the same matches back up.
   Note that this argument only holds for *transient* failures — it is what made the
   `.find` regression above a stall rather than a retry.

## Verification

`cdk synth` succeeds and all 7 bundles import. Synthesising `master` without this change
and diffing the asset manifests confirms it changes exactly one bundle, matching the new
`openDotaMatches` S3Key.

Not yet verified against production — the remaining checks need a deploy: comparing the
per-user log lines to a pre-change run, confirming `last_matchID` advances in
`dota-players-dev` for every user who had new matches, and confirming a multi-match run
posts in ascending order. The watermark is the check that matters; a run that logs nothing
and errors nothing is indistinguishable from one that quietly stopped updating.

## Note for whoever deploys

`cdk diff` shows **all seven** function asset hashes changing, not just this one. That is
pre-existing: the deployed stack is behind `master`, and #26 appears never to have been
deployed. Deploying this ships that migration for every function at the same time, which
also means a post-deploy problem in `openDotaMatches` can't be attributed to this PR
without ruling out #26 first. Worth confirming the stack's actual state before deploying —
the hash mismatch is consistent with "never deployed" but doesn't prove it.

## Follow-up, deliberately not in this PR

`discord.sendEmbed` returns `{ error: true }` rather than throwing, and `openDotaMatches`
ignores it — so `updateDB` advances `last_matchID` even when every send failed, permanently
skipping those matches. `DeadlockMatches.mjs` already guards against this. Copying it isn't
one line, because the two handlers batch differently: this one sends for all users and then
updates all users, so the send outcomes need attributing back to a steamID first. Fixing it
here would have meant a behaviour change the verification above cannot distinguish from a
refactoring mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)