### PR TITLE
DotaAnalyst: Fix the Turbo benchmarks and the hero meta ranking

### DIFF
--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -279,6 +279,7 @@ async function analyzeMatch(compactMatch, playerName) {
       total_tokens: usage.total_tokens,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,
+      reasoning_tokens: usage.reasoning_tokens,
       cached_tokens: cachedTokens,
       cache_hit_rate:
         cachedTokens > 0

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -291,6 +291,7 @@ async function analyzeMatch(match, playerId, playerName, fullMatch) {
       total_tokens: usage.total_tokens,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,
+      reasoning_tokens: usage.reasoning_tokens,
       cached_tokens: cachedTokens,
       cache_hit_rate:
         cachedTokens > 0

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -565,7 +565,7 @@ function processTeamfights(match, focusPlayerId) {
 const META_NAMESPACE = "dota-meta";
 const ONE_DAY = 24 * 60 * 60;
 
-// Combined for a large enough sample; the top bracket alone is too thin to rank on.
+// Combined for a large enough sample.
 const HIGH_SKILL_TIERS = [8, 7, 6];
 
 function selectMetric(isTurbo) {

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -623,8 +623,6 @@ function rankHeroesByWinRate(heroStats, metric) {
  * @returns {Promise<{heroes: {name: string, winRate: number}[], label: string|null}>}
  */
 async function loadMeta(isTurbo, cache = null) {
-  // Keyed by shape as well as metric: entries cached as a bare name list predate the
-  // win rates and would deserialise into a ranking of undefined heroes.
   const cacheKey = `hero-ranking:${isTurbo ? "turbo" : "ranked"}`;
 
   if (cache) {
@@ -872,9 +870,8 @@ export async function generateAnalysisPrompt(compactMatch, playerId, playerName,
     { role: 'system', content: SYSTEM_PROMPT.trim() },
   ];
 
-  // Load meta data for this match composition. loadMeta swallows a failed fetch and
-  // returns no ranking, leaving positions empty; without the length check the prompt
-  // ships an empty table the system prompt then tells the model to consult.
+  // An empty ranking still arrives as a truthy object, and shipping it would leave the
+  // model an empty table the system prompt tells it to consult.
   const meta = await loadMetaForGameMode(fullMatch, cache);
   if (meta && Object.keys(meta.positions).length > 0) {
     prompt.push({

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -733,7 +733,7 @@ CONSTRAINTS
 - NEVER include player IDs in your output. Refer to the focus player by their name, and refer to all other players by their hero name only.
 - Round integers to whole numbers; use thousands separators for large numbers.
 - Convert JSON timestamps into mm:ss format; don't add timestamps to stats without time values.
-- Format percentages as whole numbers with % symbol (e.g., 75% not 0.75).
+- Format percentages as whole numbers with % symbol (e.g., 75% not 0.75). This covers true proportions such as teamfight participation, not benchmark percentiles.
 - Comparisons only against values in this match (team averages, lane opponents, enemy cores).
 
 ROLE AWARENESS
@@ -748,6 +748,7 @@ BENCHMARKS
 - A roughly uniform shift across the economy percentiles (gold, xp, last hits) usually means the player took a different role than the hero's norm; treat that as a role choice, not as good or bad play.
 - The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
 - Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
+- Write a percentile as "94th percentile", never as a bare percentage; "94%" in this analysis means a proportion, and the two are indistinguishable to the reader otherwise.
 - Match the wording to the percentile: under 20 poor, 20-40 below average, 40-60 average, 60-80 above average, 80-95 strong, 95+ exceptional.
 
 HERO PICK ANALYSIS

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -565,48 +565,54 @@ function processTeamfights(match, focusPlayerId) {
 const META_NAMESPACE = "dota-meta";
 const ONE_DAY = 24 * 60 * 60;
 
-// OpenDota zeroes a bracket's fields when it has no sampled matches -- 8 (Immortal)
-// currently reads as all zeroes -- so the highest rankable bracket has to be found at
-// runtime rather than hardcoded.
-const MIN_BRACKET_PICKS = 10_000;
+// OpenDota's own heroes page groups Immortal, Divine and Ancient into a single
+// high-skill tier rather than reading one bracket. Summing them also keeps the ranking
+// alive when a bracket goes unsampled -- 8 currently reports all zeroes.
+const HIGH_SKILL_TIERS = [8, 7, 6];
 
-function selectMetric(heroStats, isTurbo) {
+function selectMetric(isTurbo) {
   if (isTurbo) {
-    return { picks: "turbo_picks", wins: "turbo_wins", label: "Turbo" };
+    return {
+      label: "Turbo",
+      picks: (hero) => hero.turbo_picks ?? 0,
+      wins: (hero) => hero.turbo_wins ?? 0,
+    };
   }
 
-  for (let tier = 8; tier >= 1; tier--) {
-    const picks = `${tier}_pick`;
-    const total = heroStats.reduce((sum, hero) => sum + (hero[picks] ?? 0), 0);
-    if (total >= MIN_BRACKET_PICKS) {
-      return {
-        picks,
-        wins: `${tier}_win`,
-        label: `${DotaConstants.rankTiers[tier]} bracket`,
-      };
-    }
-  }
+  const acrossTiers = (hero, suffix) =>
+    HIGH_SKILL_TIERS.reduce(
+      (sum, tier) => sum + (hero[`${tier}_${suffix}`] ?? 0),
+      0,
+    );
 
-  return null;
+  return {
+    label: HIGH_SKILL_TIERS.map((tier) => DotaConstants.rankTiers[tier]).join(
+      "/",
+    ),
+    picks: (hero) => acrossTiers(hero, "pick"),
+    wins: (hero) => acrossTiers(hero, "win"),
+  };
 }
 
 function rankHeroesByWinRate(heroStats, metric) {
-  const played = heroStats.filter((hero) => hero[metric.picks] > 0);
+  const played = heroStats
+    .map((hero) => ({
+      name: DotaConstants.heroes[hero.id]?.name,
+      picks: metric.picks(hero),
+      wins: metric.wins(hero),
+    }))
+    .filter((hero) => hero.name && hero.picks > 0);
+
   if (played.length === 0) return [];
 
   // Sorting on win rate alone lets a hero with a handful of games top the list on noise.
   const meanPicks =
-    played.reduce((sum, hero) => sum + hero[metric.picks], 0) / played.length;
+    played.reduce((sum, hero) => sum + hero.picks, 0) / played.length;
   const minPicks = meanPicks * 0.2;
 
   return played
-    .filter((hero) => hero[metric.picks] >= minPicks)
-    .map((hero) => ({
-      name: DotaConstants.heroes[hero.id]?.name,
-      winRate: hero[metric.wins] / hero[metric.picks],
-    }))
-    .filter((hero) => hero.name)
-    .sort((a, b) => b.winRate - a.winRate)
+    .filter((hero) => hero.picks >= minPicks)
+    .sort((a, b) => b.wins / b.picks - a.wins / a.picks)
     .map((hero) => hero.name);
 }
 
@@ -636,10 +642,7 @@ async function loadMeta(isTurbo, cache = null) {
     }
 
     const heroStats = await res.json();
-    const metric = selectMetric(heroStats, isTurbo);
-    if (!metric) {
-      throw new Error("No bracket had enough matches to rank");
-    }
+    const metric = selectMetric(isTurbo);
 
     const metaData = {
       heroes: rankHeroesByWinRate(heroStats, metric),

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -565,9 +565,7 @@ function processTeamfights(match, focusPlayerId) {
 const META_NAMESPACE = "dota-meta";
 const ONE_DAY = 24 * 60 * 60;
 
-// OpenDota's own heroes page groups Immortal, Divine and Ancient into a single
-// high-skill tier rather than reading one bracket. Summing them also keeps the ranking
-// alive when a bracket goes unsampled -- 8 currently reports all zeroes.
+// Combined for a large enough sample; the top bracket alone is too thin to rank on.
 const HIGH_SKILL_TIERS = [8, 7, 6];
 
 function selectMetric(isTurbo) {

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -731,6 +731,7 @@ CONSTRAINTS
 - Use only data explicitly present in JSON; never invent, infer, or speculate on missing values.
 - Focus strictly on the specified player_id; all stats must come from that player's record.
 - NEVER include player IDs in your output. Refer to the focus player by their name, and refer to all other players by their hero name only.
+- Never put a raw JSON field name in your output; name the stat in plain English (deaths per minute, not deaths_per_min).
 - Round integers to whole numbers; use thousands separators for large numbers.
 - Convert JSON timestamps into mm:ss format; don't add timestamps to stats without time values.
 - Format percentages as whole numbers with % symbol (e.g., 75% not 0.75). This covers true proportions such as teamfight participation, not benchmark percentiles.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -565,28 +565,48 @@ function processTeamfights(match, focusPlayerId) {
 const META_NAMESPACE = "dota-meta";
 const ONE_DAY = 24 * 60 * 60;
 
-// Combined for a large enough sample.
-const HIGH_SKILL_TIERS = [8, 7, 6];
+// Grouped so each is a large enough sample to rank on, highest first.
+const SKILL_GROUPS = [
+  [8, 7, 6],
+  [5, 4],
+  [3, 2, 1],
+];
 
-function selectMetric(isTurbo) {
-  if (isTurbo) {
+// Immortal is 80 with no sub-tiers, so the tiers average by position, not by value.
+function averageBracket(players) {
+  const indexes = players
+    .map((player) => DotaConstants.rankTierValues.indexOf(player.rank_tier))
+    .filter((index) => index >= 0);
+
+  if (indexes.length === 0) return null;
+
+  const mean = Math.round(
+    indexes.reduce((sum, index) => sum + index, 0) / indexes.length,
+  );
+
+  return Math.floor(DotaConstants.rankTierValues[mean] / 10);
+}
+
+function selectMetric(match) {
+  if (match.game_mode === 23) {
     return {
+      key: "turbo",
       label: "Turbo",
       picks: (hero) => hero.turbo_picks ?? 0,
       wins: (hero) => hero.turbo_wins ?? 0,
     };
   }
 
+  const bracket = averageBracket(match.players);
+  const tiers =
+    SKILL_GROUPS.find((group) => group.includes(bracket)) ?? SKILL_GROUPS[0];
+
   const acrossTiers = (hero, suffix) =>
-    HIGH_SKILL_TIERS.reduce(
-      (sum, tier) => sum + (hero[`${tier}_${suffix}`] ?? 0),
-      0,
-    );
+    tiers.reduce((sum, tier) => sum + (hero[`${tier}_${suffix}`] ?? 0), 0);
 
   return {
-    label: HIGH_SKILL_TIERS.map((tier) => DotaConstants.rankTiers[tier]).join(
-      "/",
-    ),
+    key: tiers.join("-"),
+    label: tiers.map((tier) => DotaConstants.rankTiers[tier]).join("/"),
     picks: (hero) => acrossTiers(hero, "pick"),
     wins: (hero) => acrossTiers(hero, "win"),
   };
@@ -616,12 +636,12 @@ function rankHeroesByWinRate(heroStats, metric) {
 
 /**
  * Load a hero strength ranking from OpenDota hero stats
- * @param {boolean} isTurbo - Rank on Turbo results rather than the ranked brackets
+ * @param {Object} metric - Selector from selectMetric
  * @param {Object} cache - Optional cache implementation
  * @returns {Promise<{heroes: {name: string, winRate: number}[], label: string|null}>}
  */
-async function loadMeta(isTurbo, cache = null) {
-  const cacheKey = `hero-ranking:${isTurbo ? "turbo" : "ranked"}`;
+async function loadMeta(metric, cache = null) {
+  const cacheKey = `hero-ranking:${metric.key}`;
 
   if (cache) {
     const cachedMeta = await cache.get(META_NAMESPACE, cacheKey);
@@ -640,7 +660,6 @@ async function loadMeta(isTurbo, cache = null) {
     }
 
     const heroStats = await res.json();
-    const metric = selectMetric(isTurbo);
 
     const metaData = {
       heroes: rankHeroesByWinRate(heroStats, metric),
@@ -672,7 +691,7 @@ async function loadMeta(isTurbo, cache = null) {
 async function loadMetaForGameMode(match, cache = null) {
   if (match.game_mode === 18) return undefined; // Ability Draft
 
-  const results = await loadMeta(match.game_mode === 23, cache);
+  const results = await loadMeta(selectMetric(match), cache);
   const matchHeroes = match.players
     .map((player) => DotaConstants.heroes[player.hero_id]?.name)
     .filter(Boolean);

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -612,18 +612,20 @@ function rankHeroesByWinRate(heroStats, metric) {
 
   return played
     .filter((hero) => hero.picks >= minPicks)
-    .sort((a, b) => b.wins / b.picks - a.wins / a.picks)
-    .map((hero) => hero.name);
+    .map((hero) => ({ name: hero.name, winRate: hero.wins / hero.picks }))
+    .sort((a, b) => b.winRate - a.winRate);
 }
 
 /**
  * Load a hero strength ranking from OpenDota hero stats
  * @param {boolean} isTurbo - Rank on Turbo results rather than the ranked brackets
  * @param {Object} cache - Optional cache implementation
- * @returns {Promise<{heroes: string[], label: string|null}>}
+ * @returns {Promise<{heroes: {name: string, winRate: number}[], label: string|null}>}
  */
 async function loadMeta(isTurbo, cache = null) {
-  const cacheKey = `heroes-meta:${isTurbo ? "turbo" : "ranked"}`;
+  // Keyed by shape as well as metric: entries cached as a bare name list predate the
+  // win rates and would deserialise into a ranking of undefined heroes.
+  const cacheKey = `hero-ranking:${isTurbo ? "turbo" : "ranked"}`;
 
   if (cache) {
     const cachedMeta = await cache.get(META_NAMESPACE, cacheKey);
@@ -669,7 +671,7 @@ async function loadMeta(isTurbo, cache = null) {
  * Load meta data for specific game mode and match
  * @param {Object} match - Match data
  * @param {Object} cache - Optional cache implementation
- * @returns {Promise<{positions: Object, label: string|null}|undefined>}
+ * @returns {Promise<{positions: Object, label: string|null, total: number}|undefined>}
  */
 async function loadMetaForGameMode(match, cache = null) {
   if (match.game_mode === 18) return undefined; // Ability Draft
@@ -679,15 +681,20 @@ async function loadMetaForGameMode(match, cache = null) {
     .map((player) => DotaConstants.heroes[player.hero_id]?.name)
     .filter(Boolean);
 
+  // Rank alone reads as more meaningful than it is -- the middle of the list is packed
+  // into a point or two of win rate -- so the rate goes alongside it.
   const positions = matchHeroes.reduce((acc, hero) => {
-    const position = results.heroes.indexOf(hero) + 1;
-    if (position > 0) {
-      acc[hero] = position;
+    const index = results.heroes.findIndex((ranked) => ranked.name === hero);
+    if (index >= 0) {
+      acc[hero] = {
+        rank: index + 1,
+        winRate: `${(results.heroes[index].winRate * 100).toFixed(1)}%`,
+      };
     }
     return acc;
   }, {});
 
-  return { positions, label: results.label };
+  return { positions, label: results.label, total: results.heroes.length };
 }
 
 /**
@@ -733,7 +740,15 @@ ROLE AWARENESS
 - Infer the player's role (pos 1-5) from lane, hero, and early stats.
 - Evaluate performance relative to that role's responsibilities.
 - Do not penalize supports for low tower or hero damage, or cores for low warding.
+- Benchmarks are not role-adjusted; where the inferred role differs from the hero's usual one, economy percentiles reflect that choice rather than execution.
 - Frame strengths/weaknesses/recommendations according to role expectations.
+
+BENCHMARKS
+- Percentiles compare the player against everyone on that hero regardless of role, so read the profile's shape rather than its overall level.
+- A roughly uniform shift across the economy percentiles (gold, xp, last hits) usually means the player took a different role than the hero's norm; treat that as a role choice, not as good or bad play.
+- The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
+- Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
+- Match the wording to the percentile: under 20 poor, 20-40 below average, 40-60 average, 60-80 above average, 80-95 strong, 95+ exceptional.
 
 HERO PICK ANALYSIS
 - Evaluate how the player's hero fits the team composition (initiation, wave clear, sustain, late-game scaling, etc.).
@@ -741,6 +756,7 @@ HERO PICK ANALYSIS
 - Identify if the pick counters enemy heroes or their composition (spell immunity vs magic damage, mobile heroes vs immobile lineup, etc.).
 - Consider synergies with allied heroes (setup combos, aura stacking, space creation for cores).
 - Reference meta rankings when evaluating draft quality; strong meta picks may carry harder or weaker meta picks may struggle.
+- Meta rankings carry the win rate behind each position. The middle of the list spans barely a point, so only remark on picks near the top or bottom; treat the rest as unremarkable regardless of rank.
 - Focus on impactful draft decisions; don't critique every pick but highlight notably good counters or problematic matchups.
 
 VISION & WARDING
@@ -861,7 +877,7 @@ export async function generateAnalysisPrompt(compactMatch, playerId, playerName,
   if (meta && Object.keys(meta.positions).length > 0) {
     prompt.push({
       role: 'system',
-      content: `Meta Heroes for this match (${meta.label} win rate ranking, 1=strongest):\n${JSON.stringify(meta.positions)}`,
+      content: `Meta Heroes for this match (${meta.label} win rate, ${meta.total} heroes ranked, 1=strongest):\n${JSON.stringify(meta.positions)}`,
     });
   }
 

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -96,8 +96,6 @@ const LANE_NAMES = {
 };
 
 function preparePlayers(match, focusPlayerId) {
-  const isTurbo = DotaConstants.gameModes[match.game_mode] === "Turbo";
-
   return match.players.map((player) => {
     const isFocus = player.account_id === focusPlayerId;
     const team = player.team_number === 0 ? "radiant" : "dire";
@@ -177,19 +175,20 @@ function preparePlayers(match, focusPlayerId) {
             msg.player_slot === player.player_slot && msg.type === "chat",
         )
         .map((msg) => ({ time: msg.time, message: msg.key })),
-      ...(!isTurbo
-        ? {
-            benchmarks: Object.entries(player.benchmarks).reduce(
-              (acc, [name, benchmark]) => {
-                acc[name] = (benchmark.pct * 100).toFixed(2);
-                return acc;
-              },
-              {},
-            ),
-          }
-        : {}),
+      benchmarks: prepareBenchmarks(player.benchmarks),
     };
   });
+}
+
+// pct is missing when the metric went unrecorded and NaN when OpenDota's sample for the
+// hero and game mode is empty; either reaches the prompt as the string "NaN".
+function prepareBenchmarks(benchmarks) {
+  return Object.entries(benchmarks ?? {}).reduce((acc, [name, benchmark]) => {
+    if (Number.isFinite(benchmark.pct)) {
+      acc[name] = (benchmark.pct * 100).toFixed(2);
+    }
+    return acc;
+  }, {});
 }
 
 function heroByRaw(raw) {
@@ -686,6 +685,7 @@ Return ONLY one JSON object that matches the schema exactly-no extra keys, no su
 MATCH DATA FORMAT
 - lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.)
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
+- benchmarks: Percentile rank (0-100) of the focus player against other recent players on the same hero in the same game mode. 50 is average; higher is better for every metric except deaths_per_min, where higher means the player died more than their peers
 
 CONSTRAINTS
 - Use only data explicitly present in JSON; never invent, infer, or speculate on missing values.
@@ -784,8 +784,9 @@ SCHEMA
 const GAME_MODE_ADDENDUM = {
   23: `
 TURBO MODE
-- This is a Turbo match. Economy and pacing stats (GPM, XPM, kills) are inflated by design.
-- Do not call GPM/XPM/kill rates "high/low" unless explicitly relative to this match (team averages, lane opponent, enemy heroes).
+- This is a Turbo match. Raw economy and pacing stats (GPM, XPM, kills) are inflated by design; never judge them against normal Dota expectations.
+- Do not call raw GPM/XPM/kill rates "high/low" unless relative to this match (team averages, lane opponent, enemy heroes) or to the benchmarks percentiles.
+- The benchmarks percentiles are drawn from other Turbo matches on the same hero, so they are a valid measure of whether the player's pacing was good for Turbo.
 - Popular item timings are based on professional matches and may not align with Turbo's accelerated pace; focus on item choices rather than timing criticism.
 `,
   18: `

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -563,6 +563,7 @@ function processTeamfights(match, focusPlayerId) {
 }
 
 const META_NAMESPACE = "dota-meta";
+const HERO_STATS_KEY = "hero-stats";
 const ONE_DAY = 24 * 60 * 60;
 
 // Grouped so each is a large enough sample to rank on, highest first.
@@ -590,7 +591,6 @@ function averageBracket(players) {
 function selectMetric(match) {
   if (match.game_mode === 23) {
     return {
-      key: "turbo",
       label: "Turbo",
       picks: (hero) => hero.turbo_picks ?? 0,
       wins: (hero) => hero.turbo_wins ?? 0,
@@ -605,7 +605,6 @@ function selectMetric(match) {
     tiers.reduce((sum, tier) => sum + (hero[`${tier}_${suffix}`] ?? 0), 0);
 
   return {
-    key: tiers.join("-"),
     label: tiers.map((tier) => DotaConstants.rankTiers[tier]).join("/"),
     picks: (hero) => acrossTiers(hero, "pick"),
     wins: (hero) => acrossTiers(hero, "win"),
@@ -634,6 +633,36 @@ function rankHeroesByWinRate(heroStats, metric) {
     .sort((a, b) => b.winRate - a.winRate);
 }
 
+async function loadHeroStats(cache) {
+  if (cache) {
+    const cached = await cache.get(META_NAMESPACE, HERO_STATS_KEY);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+  }
+
+  const res = await fetch("https://api.opendota.com/api/heroStats", {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Hero stats returned HTTP ${res.status}`);
+  }
+
+  const heroStats = await res.json();
+
+  if (cache) {
+    await cache.set(
+      META_NAMESPACE,
+      HERO_STATS_KEY,
+      JSON.stringify(heroStats),
+      ONE_DAY,
+    );
+  }
+
+  return heroStats;
+}
+
 /**
  * Load a hero strength ranking from OpenDota hero stats
  * @param {Object} metric - Selector from selectMetric
@@ -641,41 +670,13 @@ function rankHeroesByWinRate(heroStats, metric) {
  * @returns {Promise<{heroes: {name: string, winRate: number}[], label: string|null}>}
  */
 async function loadMeta(metric, cache = null) {
-  const cacheKey = `hero-ranking:${metric.key}`;
-
-  if (cache) {
-    const cachedMeta = await cache.get(META_NAMESPACE, cacheKey);
-    if (cachedMeta) {
-      return JSON.parse(cachedMeta);
-    }
-  }
-
   try {
-    const res = await fetch("https://api.opendota.com/api/heroStats", {
-      signal: AbortSignal.timeout(10_000),
-    });
+    const heroStats = await loadHeroStats(cache);
 
-    if (!res.ok) {
-      throw new Error(`Hero stats returned HTTP ${res.status}`);
-    }
-
-    const heroStats = await res.json();
-
-    const metaData = {
+    return {
       heroes: rankHeroesByWinRate(heroStats, metric),
       label: metric.label,
     };
-
-    if (cache) {
-      await cache.set(
-        META_NAMESPACE,
-        cacheKey,
-        JSON.stringify(metaData),
-        ONE_DAY,
-      );
-    }
-
-    return metaData;
   } catch (err) {
     console.error(`Failed to load meta information: ${err}`);
     return { heroes: [], label: null };

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -562,78 +562,103 @@ function processTeamfights(match, focusPlayerId) {
   });
 }
 
+const META_NAMESPACE = "dota-meta";
+const ONE_DAY = 24 * 60 * 60;
+
+// OpenDota zeroes a bracket's fields when it has no sampled matches -- 8 (Immortal)
+// currently reads as all zeroes -- so the highest rankable bracket has to be found at
+// runtime rather than hardcoded.
+const MIN_BRACKET_PICKS = 10_000;
+
+function selectMetric(heroStats, isTurbo) {
+  if (isTurbo) {
+    return { picks: "turbo_picks", wins: "turbo_wins", label: "Turbo" };
+  }
+
+  for (let tier = 8; tier >= 1; tier--) {
+    const picks = `${tier}_pick`;
+    const total = heroStats.reduce((sum, hero) => sum + (hero[picks] ?? 0), 0);
+    if (total >= MIN_BRACKET_PICKS) {
+      return {
+        picks,
+        wins: `${tier}_win`,
+        label: `${DotaConstants.rankTiers[tier]} bracket`,
+      };
+    }
+  }
+
+  return null;
+}
+
+function rankHeroesByWinRate(heroStats, metric) {
+  const played = heroStats.filter((hero) => hero[metric.picks] > 0);
+  if (played.length === 0) return [];
+
+  // Sorting on win rate alone lets a hero with a handful of games top the list on noise.
+  const meanPicks =
+    played.reduce((sum, hero) => sum + hero[metric.picks], 0) / played.length;
+  const minPicks = meanPicks * 0.2;
+
+  return played
+    .filter((hero) => hero[metric.picks] >= minPicks)
+    .map((hero) => ({
+      name: DotaConstants.heroes[hero.id]?.name,
+      winRate: hero[metric.wins] / hero[metric.picks],
+    }))
+    .filter((hero) => hero.name)
+    .sort((a, b) => b.winRate - a.winRate)
+    .map((hero) => hero.name);
+}
+
 /**
- * Load meta hero data from dota2protracker
+ * Load a hero strength ranking from OpenDota hero stats
+ * @param {boolean} isTurbo - Rank on Turbo results rather than the ranked brackets
  * @param {Object} cache - Optional cache implementation
- * @returns {Promise<{heroes: string[]}>}
+ * @returns {Promise<{heroes: string[], label: string|null}>}
  */
-async function loadMeta(cache = null) {
+async function loadMeta(isTurbo, cache = null) {
+  const cacheKey = `heroes-meta:${isTurbo ? "turbo" : "ranked"}`;
+
   if (cache) {
-    const cacheNamespace = 'dota-meta';
-    const cacheKey = 'heroes-meta';
-    const cachedMeta = await cache.get(cacheNamespace, cacheKey);
+    const cachedMeta = await cache.get(META_NAMESPACE, cacheKey);
     if (cachedMeta) {
       return JSON.parse(cachedMeta);
     }
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5000);
-
   try {
-    const url = new URL('https://dota2protracker.com/api/heroes/stats');
-    url.search = new URLSearchParams({
-      mmr: 7000,
-      position: 'all',
-      min_matches: 20,
-      period: 8,
-      legacy: false,
-    }).toString();
-
-    const res = await fetch(url, {
-      headers: { Referer: 'https://dota2protracker.com/meta' },
-      signal: controller.signal,
+    const res = await fetch("https://api.opendota.com/api/heroStats", {
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!res.ok) {
-      throw new Error(`Meta API returned HTTP ${res.status}`);
+      throw new Error(`Hero stats returned HTTP ${res.status}`);
     }
 
-    const data = await res.json();
-
-    // Group by hero_id and keep highest d2pt_rating
-    const heroes = {};
-    for (const hero of data) {
-      if (hero.d2pt_rating > (heroes[hero.hero_id] ?? 0)) {
-        heroes[hero.hero_id] = hero.d2pt_rating;
-      }
+    const heroStats = await res.json();
+    const metric = selectMetric(heroStats, isTurbo);
+    if (!metric) {
+      throw new Error("No bracket had enough matches to rank");
     }
-
-    // Sort by d2pt_rating descending and map to hero names
-    const sortedHeroes = Object.entries(heroes)
-      .sort(([, a], [, b]) => b - a)
-      .map(([heroId]) => DotaConstants.heroes[Number(heroId)].name ?? 'Unknown')
-      .filter(Boolean);
 
     const metaData = {
-      heroes: sortedHeroes,
+      heroes: rankHeroesByWinRate(heroStats, metric),
+      label: metric.label,
     };
 
     if (cache) {
-      const cacheNamespace = 'dota-meta';
-      const cacheKey = 'heroes-meta';
-      const ONE_DAY = 24 * 60 * 60;
-      await cache.set(cacheNamespace, cacheKey, JSON.stringify(metaData), ONE_DAY);
+      await cache.set(
+        META_NAMESPACE,
+        cacheKey,
+        JSON.stringify(metaData),
+        ONE_DAY,
+      );
     }
 
     return metaData;
   } catch (err) {
     console.error(`Failed to load meta information: ${err}`);
-    return {
-      heroes: [],
-    };
-  } finally {
-    clearTimeout(timeout);
+    return { heroes: [], label: null };
   }
 }
 
@@ -641,20 +666,25 @@ async function loadMeta(cache = null) {
  * Load meta data for specific game mode and match
  * @param {Object} match - Match data
  * @param {Object} cache - Optional cache implementation
- * @returns {Promise<Object|undefined>}
+ * @returns {Promise<{positions: Object, label: string|null}|undefined>}
  */
 async function loadMetaForGameMode(match, cache = null) {
   if (match.game_mode === 18) return undefined; // Ability Draft
 
-  const results = await loadMeta(cache);
-  const matchHeroes = match.players.map((player) => DotaConstants.heroes[player.hero_id]?.name).filter(Boolean);
-  return matchHeroes.reduce((acc, hero) => {
+  const results = await loadMeta(match.game_mode === 23, cache);
+  const matchHeroes = match.players
+    .map((player) => DotaConstants.heroes[player.hero_id]?.name)
+    .filter(Boolean);
+
+  const positions = matchHeroes.reduce((acc, hero) => {
     const position = results.heroes.indexOf(hero) + 1;
     if (position > 0) {
       acc[hero] = position;
     }
     return acc;
   }, {});
+
+  return { positions, label: results.label };
 }
 
 /**
@@ -822,14 +852,13 @@ export async function generateAnalysisPrompt(compactMatch, playerId, playerName,
   ];
 
   // Load meta data for this match composition. loadMeta swallows a failed fetch and
-  // returns no ranking, which reduces to an empty object here -- truthy, so without the
-  // length check the prompt ships an empty table the system prompt then tells the model
-  // to consult.
-  const matchHeroesMeta = await loadMetaForGameMode(fullMatch, cache);
-  if (matchHeroesMeta && Object.keys(matchHeroesMeta).length > 0) {
+  // returns no ranking, leaving positions empty; without the length check the prompt
+  // ships an empty table the system prompt then tells the model to consult.
+  const meta = await loadMetaForGameMode(fullMatch, cache);
+  if (meta && Object.keys(meta.positions).length > 0) {
     prompt.push({
       role: 'system',
-      content: `Meta Heroes for this match (high-MMR ranking, 1=strongest):\n${JSON.stringify(matchHeroesMeta)}`,
+      content: `Meta Heroes for this match (${meta.label} win rate ranking, 1=strongest):\n${JSON.stringify(meta.positions)}`,
     });
   }
 

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -576,19 +576,21 @@ const SKILL_GROUPS = [
   [3, 2, 1],
 ];
 
-// Immortal is 80 with no sub-tiers, so the tiers average by position, not by value.
-function averageBracket(players) {
+const MIN_RANKED_PLAYERS = 3;
+
+// Indexed by position because Immortal is 80 with no sub-tiers, and taken as a median
+// because one stale account would drag a mean across a group boundary.
+function medianBracket(players) {
   const indexes = players
     .map((player) => DotaConstants.rankTierValues.indexOf(player.rank_tier))
-    .filter((index) => index >= 0);
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b);
 
-  if (indexes.length === 0) return null;
+  if (indexes.length < MIN_RANKED_PLAYERS) return null;
 
-  const mean = Math.round(
-    indexes.reduce((sum, index) => sum + index, 0) / indexes.length,
-  );
+  const middle = indexes[Math.floor(indexes.length / 2)];
 
-  return Math.floor(DotaConstants.rankTierValues[mean] / 10);
+  return Math.floor(DotaConstants.rankTierValues[middle] / 10);
 }
 
 function selectMetric(match) {
@@ -600,7 +602,7 @@ function selectMetric(match) {
     };
   }
 
-  const bracket = averageBracket(match.players);
+  const bracket = medianBracket(match.players);
   const tiers =
     SKILL_GROUPS.find((group) => group.includes(bracket)) ?? SKILL_GROUPS[0];
 

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -136,6 +136,8 @@ function preparePlayers(match, focusPlayerId) {
 
     if (!isFocus) return baseStats;
 
+    const benchmarks = prepareBenchmarks(player.benchmarks);
+
     // Extract drafted abilities for Ability Draft mode from ability_upgrades_arr
     const isAbilityDraft = match.game_mode === 18;
     const draftedAbilities =
@@ -175,16 +177,17 @@ function preparePlayers(match, focusPlayerId) {
             msg.player_slot === player.player_slot && msg.type === "chat",
         )
         .map((msg) => ({ time: msg.time, message: msg.key })),
-      benchmarks: prepareBenchmarks(player.benchmarks),
+      ...(Object.keys(benchmarks).length > 0 ? { benchmarks } : {}),
     };
   });
 }
 
-// pct is missing when the metric went unrecorded and NaN when OpenDota's sample for the
-// hero and game mode is empty; either reaches the prompt as the string "NaN".
+// A zero ranks above everyone else who scored zero, so a hero that did no healing lands
+// in the 90th percentile for healing. pct is also absent or NaN when OpenDota has no
+// sample, which would reach the prompt as the string "NaN".
 function prepareBenchmarks(benchmarks) {
   return Object.entries(benchmarks ?? {}).reduce((acc, [name, benchmark]) => {
-    if (Number.isFinite(benchmark.pct)) {
+    if (Number.isFinite(benchmark.pct) && benchmark.raw > 0) {
       acc[name] = (benchmark.pct * 100).toFixed(2);
     }
     return acc;
@@ -741,7 +744,7 @@ Return ONLY one JSON object that matches the schema exactly-no extra keys, no su
 MATCH DATA FORMAT
 - lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.)
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
-- benchmarks: Percentile rank (0-100) of the focus player against other recent players on the same hero in the same game mode. 50 is average; higher is better for every metric except deaths_per_min, where higher means the player died more than their peers
+- benchmarks: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average; higher is better for every metric except deaths_per_min, where higher means the player died more than their peers
 
 CONSTRAINTS
 - Use only data explicitly present in JSON; never invent, infer, or speculate on missing values.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -748,7 +748,6 @@ BENCHMARKS
 - The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
 - Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
 - Write a percentile as "94th percentile", never as a bare percentage; "94%" in this analysis means a proportion, and the two are indistinguishable to the reader otherwise.
-- Match the wording to the percentile: under 20 poor, 20-40 below average, 40-60 average, 60-80 above average, 80-95 strong, 95+ exceptional.
 
 HERO PICK ANALYSIS
 - Evaluate how the player's hero fits the team composition (initiation, wave clear, sustain, late-game scaling, etc.).

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -821,9 +821,12 @@ export async function generateAnalysisPrompt(compactMatch, playerId, playerName,
     { role: 'system', content: SYSTEM_PROMPT.trim() },
   ];
 
-  // Load meta data for this match composition
+  // Load meta data for this match composition. loadMeta swallows a failed fetch and
+  // returns no ranking, which reduces to an empty object here -- truthy, so without the
+  // length check the prompt ships an empty table the system prompt then tells the model
+  // to consult.
   const matchHeroesMeta = await loadMetaForGameMode(fullMatch, cache);
-  if (matchHeroesMeta) {
+  if (matchHeroesMeta && Object.keys(matchHeroesMeta).length > 0) {
     prompt.push({
       role: 'system',
       content: `Meta Heroes for this match (high-MMR ranking, 1=strongest):\n${JSON.stringify(matchHeroesMeta)}`,


### PR DESCRIPTION
Three related fixes to the Dota analyst, plus one observability change. They landed together because each was found while verifying the one before it.

---

# 1. Turbo matches get benchmark percentiles

`preparePlayers` stripped `benchmarks` from the focus player on Turbo matches. Correct when written: OpenDota compared a Turbo player against the *non-Turbo* distribution, so every economy metric pinned near the 99th percentile and said nothing.

That changed upstream. `odota/core` commit `660eeed1` ("create separate benchmark set for turbo", 2025-11-22) keys the sample on mode in both directions — `svc/counts.ts` gained a `turbo` suffix on the Redis key and widened its gate to `isSignificant(match) || turbo`, and `svc/util/buildMatch.ts` reads the same key.

Confirmed against live data — 8 Turbo matches (80 players) vs 8 non-Turbo:

| | median GPM | median GPM percentile |
|---|---|---|
| Turbo | 963 | **0.49** |
| Non-Turbo | 310 | 0.08 |

Turbo GPM runs ~3× higher yet sits mid-distribution, which only happens against a Turbo reference.

**Two data defects fixed alongside it:**

- **Zero-value metrics ranked as high percentiles.** OpenDota ranks ties at the top of the zero block, so a hero that did no healing lands in the 90th percentile *for healing* — nine of ten players in the match used for testing. The prompt rules below tell the model to surface profile outliers and cite them, so it would have praised healing that never happened. Entries now need `raw > 0`; the raw totals are already in the payload, so nothing is lost.
- **`pct` can be absent or `NaN`** when OpenDota has no sample, which reached the prompt as the string `"NaN"`. Both are filtered, and the `benchmarks` key is dropped entirely when nothing survives.

---

# 2. The hero meta ranking works again, at the right skill level

The dota2protracker fetch had been failing on **every analysis** — 22 of 22 runs, all HTTP 403 with `cf-mitigated: challenge`. `cf_clearance` is bound to the TLS fingerprint of the browser that solved the challenge, so no server-side client can replay it; a 3-minute-old cookie from the matching IP still gets re-challenged.

It failed silently *and* still shipped the block: `loadMeta` caught the error and returned an empty ranking, which reduced to `{}` — truthy — so every prompt carried a `Meta Heroes` header over an empty object while the system prompt told the model to consult it. Error metrics stayed green.

**Now:**

- Sourced from OpenDota `heroStats` — no auth, no bot protection, already a dependency.
- **Turbo** ranks on `turbo_picks`/`turbo_wins` (~21.6M picks).
- **Everything else** ranks at the skill level the match was played at, using OpenDota's own groupings from their heroes page: `[8,7,6]`, `[5,4]`, `[3,2,1]`. This matters — the meta diverges sharply down the ladder, with over half the hero pool sitting 20+ places from the Divine ordering by Crusader. Every match was previously judged against the top brackets.
- The bracket is the **median** of the ranked players, not the mean, and needs at least three of them. A mean chases outliers: two Divine players plus one stale Herald smurf selected the mid-tier meta. Below three, the top group is used.
- Pro win rates are deliberately unused — ~1,370 picks across all heroes puts several at 100%.
- Heroes below 20% of the mean pick count are dropped before sorting, since win rate alone lets a tiny sample top the list.
- Each hero carries its win rate and the header carries the pool size, because rank alone overstates the middle of the list — ranks 40 and 60 are about 1.5 points apart.
- The response is cached once under one key rather than per derived ranking, so one fetch a day serves every group.

---

# 3. Output rules for the model

A `BENCHMARKS` section covering how to read the percentiles: they are hero-wide and not role-adjusted, so a uniform shift across economy metrics means a role choice rather than bad play, and the signal is divergence *within* the profile. Plus, in `CONSTRAINTS`:

- Percentiles are written `"94th percentile"`, never as a bare `%`. A run had reported teamfight participation and an XP percentile one bullet apart as `60%` and `94%`, indistinguishable to a reader.
- No raw JSON field names in output — a run reported `"63rd percentile for deaths_per_min"`.

Observed effect: percentile citations went from zero across four runs to six-plus in every run since, holding across five subsequent runs.

---

# 4. Thinking tokens are logged

`gemini-2.5-flash` reasons by default and spends several times more on thought than on the answer — ~2,400 thinking tokens against ~400 of output. `LLMClient` already captured it from `thoughtsTokenCount`; the handlers just never logged it. Added to both analysts. The thinking budget itself is left at the default.

---

## Verification

- Turbo match `8933218557` (Shadow Fiend, 1329 GPM) → `gold_per_min` 63.80th percentile, all 10 metrics. The old code sent nothing.
- Non-Turbo `8933214985` (457 GPM) → 40.70th. No regression.
- Zero-raw and `NaN` fixtures drop cleanly; an all-zero profile omits the key; a player with no `benchmarks` object yields `{}` rather than throwing.
- Bracket selection checked across Immortal through Herald lobbies, the stale-smurf and Immortal-smurf cases, and 0/1/2 ranked players falling back to the top group.
- One `heroStats` fetch and one cache key serve five matches across three skill groups plus Turbo.
- Win-rate arithmetic reproduces OpenDota's `winRateHigh` exactly.
- Meta failure path returns an empty ranking, which the guard suppresses. Ability Draft still returns early.
- `cdk synth` clean; all 7 bundles load.

`prettier -c` flags `lib/DotaMatchProcessor.mjs`, but did so before this branch too — the unrelated reformatting is left out to keep the diff readable.

## Deployment

All of this is already deployed to production, in stages, while comparing analyst output between changes. Master is unchanged.

`DotaAnalyst` caches finished analyses under `match:<id>:player:<id>`, so already-analysed matches keep their old write-up until Reanalyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
