### PR TITLE
Analysts: Enforce the output schema and fall back when a model is out of quota

### DIFF
--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -200,21 +200,17 @@ export async function handler(event, context) {
             : `Match Analysis - ${playerHero}`,
           description: analysis.summary,
           fields: [
-            {
-              name: "Highlights",
-              value: analysis.strengths.map((txt) => `- ${txt}`).join("\n"),
-            },
-            {
-              name: "Focus areas",
-              value: analysis.weaknesses.map((txt) => `- ${txt}`).join("\n"),
-            },
-            {
-              name: "Recommendations",
-              value: analysis.recommendations
-                .map((txt) => `- ${txt}`)
-                .join("\n"),
-            },
-          ],
+            { name: "Highlights", items: analysis.strengths },
+            { name: "Focus areas", items: analysis.weaknesses },
+            { name: "Recommendations", items: analysis.recommendations },
+          ]
+            // Discord rejects an embed field with an empty value, which would
+            // lose the whole analysis over one section the model left empty.
+            .filter(({ items }) => items?.length)
+            .map(({ name, items }) => ({
+              name,
+              value: items.map((txt) => `- ${txt}`).join("\n"),
+            })),
         },
       ],
       allowed_mentions: { parse: [] },

--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -5,6 +5,7 @@ import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
+import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import * as DeadlockConstants from "../lib/DeadlockConstants.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
@@ -270,7 +271,7 @@ async function analyzeMatch(compactMatch, playerName) {
 
   console.log("Compact Match Data:", JSON.stringify(compactMatch, null, 2));
 
-  const response = await llm.call(prompt, "gemini-2.5-flash");
+  const response = await llm.call(prompt, "gemini-2.5-flash", ANALYSIS_SCHEMA);
 
   if (response.usage) {
     const usage = response.usage;

--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -5,7 +5,11 @@ import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
-import { ANALYSIS_SCHEMA, ANALYSIS_MODELS } from "../lib/analysis.mjs";
+import {
+  ANALYSIS_SCHEMA,
+  ANALYSIS_MODELS,
+  analysisFields,
+} from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import * as DeadlockConstants from "../lib/DeadlockConstants.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
@@ -199,18 +203,7 @@ export async function handler(event, context) {
             ? `Match Analysis - ${playerName} - ${playerHero}`
             : `Match Analysis - ${playerHero}`,
           description: analysis.summary,
-          fields: [
-            { name: "Highlights", items: analysis.strengths },
-            { name: "Focus areas", items: analysis.weaknesses },
-            { name: "Recommendations", items: analysis.recommendations },
-          ]
-            // Discord rejects an embed field with an empty value, which would
-            // lose the whole analysis over one section the model left empty.
-            .filter(({ items }) => items?.length)
-            .map(({ name, items }) => ({
-              name,
-              value: items.map((txt) => `- ${txt}`).join("\n"),
-            })),
+          fields: analysisFields(analysis),
         },
       ],
       allowed_mentions: { parse: [] },

--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -5,7 +5,7 @@ import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
-import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
+import { ANALYSIS_SCHEMA, ANALYSIS_MODELS } from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import * as DeadlockConstants from "../lib/DeadlockConstants.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
@@ -271,12 +271,17 @@ async function analyzeMatch(compactMatch, playerName) {
 
   console.log("Compact Match Data:", JSON.stringify(compactMatch, null, 2));
 
-  const response = await llm.call(prompt, "gemini-2.5-flash", ANALYSIS_SCHEMA);
+  const response = await llm.callWithFallback(
+    prompt,
+    ANALYSIS_MODELS,
+    ANALYSIS_SCHEMA,
+  );
 
   if (response.usage) {
     const usage = response.usage;
     const cachedTokens = usage.cached_tokens;
     console.log("Token usage:", {
+      model: response.model,
       total_tokens: usage.total_tokens,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -4,7 +4,7 @@ import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import OpenDotaAPI from "../lib/OpenDotaAPI.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
-import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
+import { ANALYSIS_SCHEMA, ANALYSIS_MODELS } from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import DotaConstants from "../lib/DotaConstants.mjs";
 import {
@@ -283,12 +283,17 @@ async function analyzeMatch(match, playerId, playerName, fullMatch) {
 
   console.log("Analyzing Match", { prompt });
 
-  const response = await llm.call(prompt, "gemini-2.5-flash", ANALYSIS_SCHEMA);
+  const response = await llm.callWithFallback(
+    prompt,
+    ANALYSIS_MODELS,
+    ANALYSIS_SCHEMA,
+  );
 
   if (response.usage) {
     const usage = response.usage;
     const cachedTokens = usage.cached_tokens;
     console.log("Token usage:", {
+      model: response.model,
       total_tokens: usage.total_tokens,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -200,21 +200,17 @@ export async function handler(event, context) {
           title: `Match Analysis - ${playerName} - ${playerHero}`,
           description: analysis.summary,
           fields: [
-            {
-              name: "Highlights",
-              value: analysis.strengths.map((txt) => `- ${txt}`).join("\n"),
-            },
-            {
-              name: "Focus areas",
-              value: analysis.weaknesses.map((txt) => `- ${txt}`).join("\n"),
-            },
-            {
-              name: "Recommendations",
-              value: analysis.recommendations
-                .map((txt) => `- ${txt}`)
-                .join("\n"),
-            },
-          ],
+            { name: "Highlights", items: analysis.strengths },
+            { name: "Focus areas", items: analysis.weaknesses },
+            { name: "Recommendations", items: analysis.recommendations },
+          ]
+            // Discord rejects an embed field with an empty value, which would
+            // lose the whole analysis over one section the model left empty.
+            .filter(({ items }) => items?.length)
+            .map(({ name, items }) => ({
+              name,
+              value: items.map((txt) => `- ${txt}`).join("\n"),
+            })),
         },
       ],
       allowed_mentions: { parse: [] },

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -4,6 +4,7 @@ import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import OpenDotaAPI from "../lib/OpenDotaAPI.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
+import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import DotaConstants from "../lib/DotaConstants.mjs";
 import {
@@ -282,7 +283,7 @@ async function analyzeMatch(match, playerId, playerName, fullMatch) {
 
   console.log("Analyzing Match", { prompt });
 
-  const response = await llm.call(prompt, "gemini-2.5-flash");
+  const response = await llm.call(prompt, "gemini-2.5-flash", ANALYSIS_SCHEMA);
 
   if (response.usage) {
     const usage = response.usage;

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -4,7 +4,11 @@ import Discord from "../lib/Discord.mjs";
 import cache from "../lib/cache.mjs";
 import OpenDotaAPI from "../lib/OpenDotaAPI.mjs";
 import LLMClient from "../lib/LLMClient.mjs";
-import { ANALYSIS_SCHEMA, ANALYSIS_MODELS } from "../lib/analysis.mjs";
+import {
+  ANALYSIS_SCHEMA,
+  ANALYSIS_MODELS,
+  analysisFields,
+} from "../lib/analysis.mjs";
 import secrets from "../lib/secrets.mjs";
 import DotaConstants from "../lib/DotaConstants.mjs";
 import {
@@ -199,18 +203,7 @@ export async function handler(event, context) {
         {
           title: `Match Analysis - ${playerName} - ${playerHero}`,
           description: analysis.summary,
-          fields: [
-            { name: "Highlights", items: analysis.strengths },
-            { name: "Focus areas", items: analysis.weaknesses },
-            { name: "Recommendations", items: analysis.recommendations },
-          ]
-            // Discord rejects an embed field with an empty value, which would
-            // lose the whole analysis over one section the model left empty.
-            .filter(({ items }) => items?.length)
-            .map(({ name, items }) => ({
-              name,
-              value: items.map((txt) => `- ${txt}`).join("\n"),
-            })),
+          fields: analysisFields(analysis),
         },
       ],
       allowed_mentions: { parse: [] },

--- a/lib/DeadlockMatchProcessor.mjs
+++ b/lib/DeadlockMatchProcessor.mjs
@@ -1379,7 +1379,7 @@ STRENGTHS (1-5 items, <=25 words each)
 - Meaningful advantages/successes. Include metrics only if useful.
 
 WEAKNESSES (1-5 items, <=25 words each)
-- Significant shortfalls. Omit if no clear weakness.
+- Significant shortfalls.
 
 RECOMMENDATIONS (1-3 items, <=25 words each)
 - Actionable by player alone; avoid vague language. At least one should build on a listed strength.

--- a/lib/DeadlockMatchProcessor.mjs
+++ b/lib/DeadlockMatchProcessor.mjs
@@ -1389,7 +1389,7 @@ SCHEMA
   "summary": string,
   "strengths": string[],
   "weaknesses": string[],
-  "recommendations": string[],
+  "recommendations": string[]
 }
 `;
 

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -840,7 +840,7 @@ STRENGTHS (1-5 items, <=25 words each)
 - Meaningful advantages/successes for the role. Include metrics/timestamps only if useful.
 
 WEAKNESSES (1-5 items, <=25 words each)
-- Significant shortfalls relative to role. Omit if no clear weakness.
+- Significant shortfalls relative to role.
 
 RECOMMENDATIONS (1-3 items, <=25 words each)
 - Actionable by player alone; avoid vague language. At least one should build on a listed strength.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -852,7 +852,7 @@ SCHEMA
   "summary": string,
   "strengths": string[],
   "weaknesses": string[],
-  "recommendations": string[],
+  "recommendations": string[]
 }
 `;
 

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -4,10 +4,9 @@ const RETRY_DELAY_MS = 300;
 /**
  * Classifies a provider's HTTP failure along two independent axes.
  *
- * `retryable` -- worth asking this same model again. Only a 5xx qualifies: a
- * 429 that asks for a 30s retryDelay answered with a 300ms backoff cannot
- * succeed and is the one thing here that would look like abuse, and a 4xx is
- * rejected identically every time.
+ * `retryable` -- worth asking this same model again. Only a 5xx qualifies.
+ * Answering a 429 that asked for a 30s delay with a 300ms backoff cannot
+ * succeed, and the rest of the 4xx range is rejected identically every time.
  *
  * `tryNextModel` -- worth asking a different model. Rate limits qualify because
  * the caps are per model, and so does a 404: providers retire models, and a
@@ -42,10 +41,10 @@ export default class LLMClient {
    * @param {string} model - Model name (e.g., 'gpt-5', 'claude-sonnet-4-5', 'gemini-2.5-flash')
    * @param {object} [schema] - JSON Schema to constrain the output. All three
    *   providers accept the same standard schema; only where it goes in the
-   *   request body differs. Without it they are asked for JSON but not held to
-   *   it, and some models emit a duplicated closing brace or a code fence.
-   *   Requires `additionalProperties: false` and a complete `required` list,
-   *   which is the strictest of the three providers' rules.
+   *   request body differs. Must set `additionalProperties: false` and list
+   *   every property in `required`, which OpenAI's strict mode demands and the
+   *   other two tolerate. Without a schema the model is asked for JSON but not
+   *   held to it, and some emit a duplicated closing brace or a code fence.
    * @returns {Promise<{output: object, usage: object, response_time_ms: number}>}
    */
   async call(messages, model, schema) {
@@ -76,12 +75,10 @@ export default class LLMClient {
   }
 
   /**
-   * Call the first model that answers, stepping down the list when one is out
-   * of quota or its provider is overloaded.
-   *
-   * Steps down on rate limits, provider blips, and models that no longer exist.
-   * A rejected schema or a malformed prompt does not: it fails identically on
-   * every model, so walking the chain returns the same error more slowly.
+   * Call the first model that answers, stepping down on rate limits, provider
+   * blips, and models that no longer exist. A rejected schema or a malformed
+   * prompt does not step down: it fails identically on every model, so walking
+   * the chain would return the same error more slowly.
    *
    * @param {Array} messages - Array of {role, content} messages
    * @param {string[]} models - Models to try, best first
@@ -168,10 +165,9 @@ export default class LLMClient {
         const rawContent = data.choices[0].message.content;
 
         // OpenAI counts reasoning inside completion_tokens, where Gemini and
-        // Anthropic report it alongside. Subtract it so every provider means
-        // the same thing by completion_tokens and callers can add the two
-        // without double counting -- prompt + completion + reasoning is the
-        // total everywhere.
+        // Anthropic report it alongside. Subtracting it makes prompt +
+        // completion + reasoning the total on all three, so a caller can add
+        // the two without knowing which provider answered.
         const reasoningTokens =
           data.usage.completion_tokens_details?.reasoning_tokens || 0;
 
@@ -312,8 +308,8 @@ export default class LLMClient {
       contents,
       generationConfig: {
         response_mime_type: "application/json",
-        // response_json_schema takes a standard JSON Schema; the older
-        // response_schema field wants Gemini's own uppercase type names.
+        // Not response_schema: that field is an OpenAPI subset and rejects
+        // additionalProperties, which OpenAI's strict mode requires.
         ...(schema && { response_json_schema: schema }),
       },
     };

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -20,22 +20,28 @@ export default class LLMClient {
    * Call a model from any provider (auto-detects provider from model name)
    * @param {Array} messages - Array of {role, content} messages
    * @param {string} model - Model name (e.g., 'gpt-5', 'claude-sonnet-4-5', 'gemini-2.5-flash')
+   * @param {object} [schema] - JSON Schema to constrain the output. All three
+   *   providers accept the same standard schema; only where it goes in the
+   *   request body differs. Without it they are asked for JSON but not held to
+   *   it, and some models emit a duplicated closing brace or a code fence.
+   *   Requires `additionalProperties: false` and a complete `required` list,
+   *   which is the strictest of the three providers' rules.
    * @returns {Promise<{output: object, usage: object, response_time_ms: number}>}
    */
-  async call(messages, model) {
+  async call(messages, model, schema) {
     const startTime = Date.now();
     const provider = this.#getProviderFromModel(model);
 
     let result;
     switch (provider) {
       case "openai":
-        result = await this.#callOpenAI(model, messages);
+        result = await this.#callOpenAI(model, messages, schema);
         break;
       case "anthropic":
-        result = await this.#callAnthropic(model, messages);
+        result = await this.#callAnthropic(model, messages, schema);
         break;
       case "gemini":
-        result = await this.#callGemini(model, messages);
+        result = await this.#callGemini(model, messages, schema);
         break;
       default:
         throw new Error(`Unknown provider: ${provider}`);
@@ -65,13 +71,19 @@ export default class LLMClient {
    * Call OpenAI API
    * @param {string} model - Model name (e.g., 'gpt-5')
    * @param {Array} messages - Array of {role, content} messages
+   * @param {object} [schema] - JSON Schema to constrain the output
    * @returns {Promise<{output: object, usage: object}>}
    */
-  async #callOpenAI(model, messages) {
+  async #callOpenAI(model, messages, schema) {
     const body = {
       model,
       messages,
-      response_format: { type: "json_object" },
+      response_format: schema
+        ? {
+            type: "json_schema",
+            json_schema: { name: "output", strict: true, schema },
+          }
+        : { type: "json_object" },
     };
 
     let attempt = 0;
@@ -129,9 +141,10 @@ export default class LLMClient {
    * Call Anthropic Claude API
    * @param {string} model - Model name (e.g., 'claude-sonnet-4-5')
    * @param {Array} messages - Array of {role, content} messages
+   * @param {object} [schema] - JSON Schema to constrain the output
    * @returns {Promise<{output: object, usage: object}>}
    */
-  async #callAnthropic(model, messages) {
+  async #callAnthropic(model, messages, schema) {
     // Extract system message from messages array
     const systemMessage = messages.find((m) => m.role === "system");
     const userMessages = messages.filter((m) => m.role !== "system");
@@ -144,6 +157,10 @@ export default class LLMClient {
 
     if (systemMessage) {
       body.system = systemMessage.content;
+    }
+
+    if (schema) {
+      body.output_config = { format: { type: "json_schema", schema } };
     }
 
     let attempt = 0;
@@ -213,9 +230,10 @@ export default class LLMClient {
    * Call Google Gemini API
    * @param {string} model - Model name (e.g., 'gemini-2.5-flash')
    * @param {Array} messages - Array of {role, content} messages
+   * @param {object} [schema] - JSON Schema to constrain the output
    * @returns {Promise<{output: object, usage: object}>}
    */
-  async #callGemini(model, messages) {
+  async #callGemini(model, messages, schema) {
     // Gemini has a different message format
     // System messages are sent as system_instruction
     // User/assistant messages are converted to contents array
@@ -233,6 +251,9 @@ export default class LLMClient {
       contents,
       generationConfig: {
         response_mime_type: "application/json",
+        // response_json_schema takes a standard JSON Schema; the older
+        // response_schema field wants Gemini's own uppercase type names.
+        ...(schema && { response_json_schema: schema }),
       },
     };
 

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -170,15 +170,22 @@ export default class LLMClient {
 
         const rawContent = data.choices[0].message.content;
 
+        // OpenAI counts reasoning inside completion_tokens, where Gemini and
+        // Anthropic report it alongside. Subtract it so every provider means
+        // the same thing by completion_tokens and callers can add the two
+        // without double counting -- prompt + completion + reasoning is the
+        // total everywhere.
+        const reasoningTokens =
+          data.usage.completion_tokens_details?.reasoning_tokens || 0;
+
         return {
           output: JSON.parse(rawContent),
           usage: {
             prompt_tokens: data.usage.prompt_tokens,
-            completion_tokens: data.usage.completion_tokens,
+            completion_tokens: data.usage.completion_tokens - reasoningTokens,
             cached_tokens: data.usage.prompt_tokens_details?.cached_tokens || 0,
             total_tokens: data.usage.total_tokens,
-            reasoning_tokens:
-              data.usage.completion_tokens_details?.reasoning_tokens || 0,
+            reasoning_tokens: reasoningTokens,
           },
         };
       } catch (err) {

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -2,6 +2,30 @@ const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;
 
 /**
+ * Classifies a provider's HTTP failure along two independent axes.
+ *
+ * `retryable` -- worth asking this same model again. Only a 5xx qualifies: a
+ * 429 that asks for a 30s retryDelay answered with a 300ms backoff cannot
+ * succeed and is the one thing here that would look like abuse, and a 4xx is
+ * rejected identically every time.
+ *
+ * `tryNextModel` -- worth asking a different model. Rate limits qualify because
+ * the caps are per model, and so does a 404: providers retire models, and a
+ * stale name in a fallback chain must not take down the models below it.
+ */
+function providerError(provider, status, text) {
+  const err = new Error(`${provider} error ${status}: ${text}`);
+  err.status = status;
+  err.retryable = status >= 500;
+  err.tryNextModel = status === 429 || status === 404 || status >= 500;
+  err.missing = status === 404;
+  // Gemini reports the per-minute and per-day caps identically; the difference
+  // only changes the log line, so a missed match here costs nothing.
+  err.daily = status === 429 && text.includes("PerDay");
+  return err;
+}
+
+/**
  * Unified LLM client for OpenAI, Anthropic, and Google Gemini
  * All methods use standard fetch() - no external dependencies
  */
@@ -56,6 +80,43 @@ export default class LLMClient {
   }
 
   /**
+   * Call the first model that answers, stepping down the list when one is out
+   * of quota or its provider is overloaded.
+   *
+   * Steps down on rate limits, provider blips, and models that no longer exist.
+   * A rejected schema or a malformed prompt does not: it fails identically on
+   * every model, so walking the chain returns the same error more slowly.
+   *
+   * @param {Array} messages - Array of {role, content} messages
+   * @param {string[]} models - Models to try, best first
+   * @param {object} [schema] - JSON Schema to constrain the output
+   * @returns {Promise<{output: object, usage: object, response_time_ms: number, model: string}>}
+   *   `model` is the one that actually answered, which is not always models[0]
+   */
+  async callWithFallback(messages, models, schema) {
+    if (!models?.length) {
+      throw new Error("callWithFallback requires at least one model");
+    }
+
+    let lastErr;
+
+    for (const model of models) {
+      try {
+        const result = await this.call(messages, model, schema);
+        return { ...result, model };
+      } catch (err) {
+        if (!err.tryNextModel) throw err;
+        lastErr = err;
+        console.warn(
+          `${model} ${err.missing ? "does not exist -- retired or renamed?" : `unavailable${err.daily ? " (daily quota exhausted)" : ""}`}, falling back`,
+        );
+      }
+    }
+
+    throw lastErr;
+  }
+
+  /**
    * Determine provider from model name
    * @param {string} model - Model name
    * @returns {string} - Provider name
@@ -102,10 +163,7 @@ export default class LLMClient {
 
         if (!res.ok) {
           const text = await res.text().catch(() => "");
-          if (res.status === 429 || res.status >= 500) {
-            throw new Error(`retryable ${res.status}: ${text}`);
-          }
-          throw new Error(`OpenAI error ${res.status}: ${text}`);
+          throw providerError("OpenAI", res.status, text);
         }
 
         const data = await res.json();
@@ -126,6 +184,7 @@ export default class LLMClient {
       } catch (err) {
         console.error(`OpenAI attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
+        if (err.status && !err.retryable) break;
         attempt += 1;
         if (attempt >= MAX_ATTEMPTS) break;
         await new Promise((resolve) =>
@@ -180,10 +239,7 @@ export default class LLMClient {
 
         if (!res.ok) {
           const text = await res.text().catch(() => "");
-          if (res.status === 429 || res.status >= 500) {
-            throw new Error(`retryable ${res.status}: ${text}`);
-          }
-          throw new Error(`Anthropic error ${res.status}: ${text}`);
+          throw providerError("Anthropic", res.status, text);
         }
 
         const data = await res.json();
@@ -215,6 +271,7 @@ export default class LLMClient {
       } catch (err) {
         console.error(`Anthropic attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
+        if (err.status && !err.retryable) break;
         attempt += 1;
         if (attempt >= MAX_ATTEMPTS) break;
         await new Promise((resolve) =>
@@ -280,10 +337,7 @@ export default class LLMClient {
 
         if (!res.ok) {
           const text = await res.text().catch(() => "");
-          if (res.status === 429 || res.status >= 500) {
-            throw new Error(`retryable ${res.status}: ${text}`);
-          }
-          throw new Error(`Gemini error ${res.status}: ${text}`);
+          throw providerError("Gemini", res.status, text);
         }
 
         const data = await res.json();
@@ -315,6 +369,7 @@ export default class LLMClient {
       } catch (err) {
         console.error(`Gemini attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
+        if (err.status && !err.retryable) break;
         attempt += 1;
         if (attempt >= MAX_ATTEMPTS) break;
         await new Promise((resolve) =>

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -18,10 +18,6 @@ function providerError(provider, status, text) {
   err.status = status;
   err.retryable = status >= 500;
   err.tryNextModel = status === 429 || status === 404 || status >= 500;
-  err.missing = status === 404;
-  // Gemini reports the per-minute and per-day caps identically; the difference
-  // only changes the log line, so a missed match here costs nothing.
-  err.daily = status === 429 && text.includes("PerDay");
   return err;
 }
 
@@ -108,7 +104,8 @@ export default class LLMClient {
         if (!err.tryNextModel) throw err;
         lastErr = err;
         console.warn(
-          `${model} ${err.missing ? "does not exist -- retired or renamed?" : `unavailable${err.daily ? " (daily quota exhausted)" : ""}`}, falling back`,
+          `${model} unavailable, falling back:`,
+          err.message.slice(0, 160),
         );
       }
     }

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -1,25 +1,26 @@
 /**
- * What the two analysts ask for, and who they ask.
+ * What the two analysts ask the model for, and how the answer is rendered.
  */
 
+const stringList = { type: "array", items: { type: "string" } };
+
+const properties = {
+  summary: { type: "string" },
+  strengths: stringList,
+  weaknesses: stringList,
+  recommendations: stringList,
+};
+
 /**
- * Output shape both analysts render straight into a Discord embed.
- *
- * Passed to the LLM as a schema so the provider constrains decoding rather than
- * merely being asked for JSON. The prose SCHEMA blocks in DotaMatchProcessor and
- * DeadlockMatchProcessor describe the same shape and must stay in sync -- they
- * carry the per-field semantics and the item/word limits, which JSON Schema
- * cannot express on any of the three providers.
+ * Passed to the LLM so the provider constrains decoding rather than merely
+ * being asked for JSON. The prose SCHEMA blocks in the two match processors
+ * describe the same shape and carry the per-field semantics and the item and
+ * word limits, which JSON Schema cannot express on any of the three providers.
  */
 export const ANALYSIS_SCHEMA = {
   type: "object",
-  properties: {
-    summary: { type: "string" },
-    strengths: { type: "array", items: { type: "string" } },
-    weaknesses: { type: "array", items: { type: "string" } },
-    recommendations: { type: "array", items: { type: "string" } },
-  },
-  required: ["summary", "strengths", "weaknesses", "recommendations"],
+  properties,
+  required: Object.keys(properties),
   additionalProperties: false,
 };
 
@@ -28,8 +29,6 @@ export const ANALYSIS_SCHEMA = {
  *
  * Every entry is on the Gemini free tier, which caps each model separately at
  * 20 requests a day -- so a step down is a fresh 20, not a share of one pool.
- * That is the whole point of the chain: the daily cap is the limit we actually
- * hit, and it is per model.
  */
 export const ANALYSIS_MODELS = [
   "gemini-3.6-flash",
@@ -37,3 +36,20 @@ export const ANALYSIS_MODELS = [
   "gemini-2.5-flash",
   "gemini-3.5-flash-lite",
 ];
+
+/**
+ * Discord rejects an embed field with an empty value, which would lose the
+ * whole analysis over one section the model left empty.
+ */
+export function analysisFields(analysis) {
+  return [
+    ["Highlights", analysis.strengths],
+    ["Focus areas", analysis.weaknesses],
+    ["Recommendations", analysis.recommendations],
+  ]
+    .filter(([, items]) => items?.length)
+    .map(([name, items]) => ({
+      name,
+      value: items.map((txt) => `- ${txt}`).join("\n"),
+    }));
+}

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -1,4 +1,8 @@
 /**
+ * What the two analysts ask for, and who they ask.
+ */
+
+/**
  * Output shape both analysts render straight into a Discord embed.
  *
  * Passed to the LLM as a schema so the provider constrains decoding rather than
@@ -18,3 +22,18 @@ export const ANALYSIS_SCHEMA = {
   required: ["summary", "strengths", "weaknesses", "recommendations"],
   additionalProperties: false,
 };
+
+/**
+ * Tried in order, best first, stepping down when a model is out of quota.
+ *
+ * Every entry is on the Gemini free tier, which caps each model separately at
+ * 20 requests a day -- so a step down is a fresh 20, not a share of one pool.
+ * That is the whole point of the chain: the daily cap is the limit we actually
+ * hit, and it is per model.
+ */
+export const ANALYSIS_MODELS = [
+  "gemini-3.6-flash",
+  "gemini-3.5-flash",
+  "gemini-2.5-flash",
+  "gemini-3.5-flash-lite",
+];

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -13,9 +13,12 @@ const properties = {
 
 /**
  * Passed to the LLM so the provider constrains decoding rather than merely
- * being asked for JSON. The prose SCHEMA blocks in the two match processors
- * describe the same shape and carry the per-field semantics and the item and
- * word limits, which JSON Schema cannot express on any of the three providers.
+ * being asked for JSON.
+ *
+ * The prose SCHEMA blocks in the two match processors must stay in sync with
+ * this. They also carry the per-field semantics and the item and word limits,
+ * which this does not enforce -- models still return four- and five-item lists
+ * against a stated limit of three.
  */
 export const ANALYSIS_SCHEMA = {
   type: "object",
@@ -27,8 +30,8 @@ export const ANALYSIS_SCHEMA = {
 /**
  * Tried in order, best first, stepping down when a model is out of quota.
  *
- * Every entry is on the Gemini free tier, which caps each model separately at
- * 20 requests a day -- so a step down is a fresh 20, not a share of one pool.
+ * The Gemini free tier caps each model separately -- 20 requests a day for
+ * gemini-2.5-flash -- so a step down is a fresh allowance, not a share of one.
  */
 export const ANALYSIS_MODELS = [
   "gemini-3.6-flash",

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -1,0 +1,20 @@
+/**
+ * Output shape both analysts render straight into a Discord embed.
+ *
+ * Passed to the LLM as a schema so the provider constrains decoding rather than
+ * merely being asked for JSON. The prose SCHEMA blocks in DotaMatchProcessor and
+ * DeadlockMatchProcessor describe the same shape and must stay in sync -- they
+ * carry the per-field semantics and the item/word limits, which JSON Schema
+ * cannot express on any of the three providers.
+ */
+export const ANALYSIS_SCHEMA = {
+  type: "object",
+  properties: {
+    summary: { type: "string" },
+    strengths: { type: "array", items: { type: "string" } },
+    weaknesses: { type: "array", items: { type: "string" } },
+    recommendations: { type: "array", items: { type: "string" } },
+  },
+  required: ["summary", "strengths", "weaknesses", "recommendations"],
+  additionalProperties: false,
+};

--- a/llm-evals/evaluate-results.mjs
+++ b/llm-evals/evaluate-results.mjs
@@ -308,9 +308,10 @@ function displayRankings(data, ratings, game, matchCount) {
     if (result.tokens) {
       stats[modelId].tokens.push(result.tokens);
 
-      // Calculate cost for this result (backward compatibility)
-      const cost =
-        result.cost_usd || calculateCost(data.models[modelId], result.tokens);
+      // Recomputed rather than read from cost_usd: that field was written at
+      // generation time, so a file produced under older pricing would compare
+      // its models against a different table than a file produced today.
+      const cost = calculateCost(data.models[modelId], result.tokens);
       if (cost !== null) {
         stats[modelId].costs.push(cost);
       }
@@ -615,9 +616,7 @@ async function main() {
               const costs = [];
               for (const result of gameResults) {
                 if (result.tokens) {
-                  const cost =
-                    result.cost_usd ||
-                    calculateCost(ranking.model_name, result.tokens);
+                  const cost = calculateCost(ranking.model_name, result.tokens);
                   if (cost !== null) {
                     costs.push(cost);
                   }

--- a/llm-evals/evaluate-results.mjs
+++ b/llm-evals/evaluate-results.mjs
@@ -4,7 +4,7 @@ import readline from "readline";
 const ELO_K_FACTOR = 32;
 const INITIAL_ELO = 1500;
 
-// Pricing per million tokens (as of October 2025)
+// Pricing per million tokens (as of August 2026)
 const PRICING = {
   "gpt-5": { input: 2.5, output: 10.0 },
   "gpt-5-mini": { input: 0.4, output: 1.6 },
@@ -12,9 +12,12 @@ const PRICING = {
   "claude-opus-4-1": { input: 15.0, output: 75.0 },
   "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
   "claude-haiku-4-5": { input: 0.8, output: 4.0 },
-  "gemini-2.5-pro": { input: 1.25, output: 5.0 },
-  "gemini-2.5-flash": { input: 0.075, output: 0.3 },
-  "gemini-2.5-flash-lite": { input: 0.0375, output: 0.15 },
+  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gemini-3.5-flash": { input: 1.5, output: 9.0 },
+  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
+  "gemini-3.6-flash": { input: 1.5, output: 7.5 },
 };
 
 function calculateCost(model, tokens) {
@@ -24,7 +27,11 @@ function calculateCost(model, tokens) {
   }
 
   const inputCost = (tokens.prompt_tokens / 1_000_000) * pricing.input;
-  const outputCost = (tokens.completion_tokens / 1_000_000) * pricing.output;
+  // Thinking tokens bill as output but are reported separately, so a reasoning
+  // model looks ~5x cheaper than it is if they are left out.
+  const outputTokens =
+    tokens.completion_tokens + (tokens.reasoning_tokens || 0);
+  const outputCost = (outputTokens / 1_000_000) * pricing.output;
 
   return inputCost + outputCost;
 }

--- a/llm-evals/evaluate-results.mjs
+++ b/llm-evals/evaluate-results.mjs
@@ -1,40 +1,9 @@
 import fs from "fs/promises";
 import readline from "readline";
+import { calculateCost } from "./lib/pricing.mjs";
 
 const ELO_K_FACTOR = 32;
 const INITIAL_ELO = 1500;
-
-// Pricing per million tokens (as of August 2026)
-const PRICING = {
-  "gpt-5": { input: 2.5, output: 10.0 },
-  "gpt-5-mini": { input: 0.4, output: 1.6 },
-  "gpt-5-nano": { input: 0.1, output: 0.4 },
-  "claude-opus-4-1": { input: 15.0, output: 75.0 },
-  "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
-  "claude-haiku-4-5": { input: 0.8, output: 4.0 },
-  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
-  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
-  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
-  "gemini-3.5-flash": { input: 1.5, output: 9.0 },
-  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
-  "gemini-3.6-flash": { input: 1.5, output: 7.5 },
-};
-
-function calculateCost(model, tokens) {
-  const pricing = PRICING[model];
-  if (!pricing || !tokens) {
-    return null;
-  }
-
-  const inputCost = (tokens.prompt_tokens / 1_000_000) * pricing.input;
-  // Thinking tokens bill as output but are reported separately, so a reasoning
-  // model looks ~5x cheaper than it is if they are left out.
-  const outputTokens =
-    tokens.completion_tokens + (tokens.reasoning_tokens || 0);
-  const outputCost = (outputTokens / 1_000_000) * pricing.output;
-
-  return inputCost + outputCost;
-}
 
 function parseArgs() {
   const args = process.argv.slice(2);

--- a/llm-evals/generate-eval.mjs
+++ b/llm-evals/generate-eval.mjs
@@ -1,5 +1,6 @@
 import LLMClient from "../lib/LLMClient.mjs";
 import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
+import { calculateCost, isPriced } from "./lib/pricing.mjs";
 import OpenDotaAPI from "../lib/OpenDotaAPI.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
 import NoOpCache from "./lib/NoOpCache.mjs";
@@ -46,45 +47,6 @@ const MODELS = [
   "gemini-3.5-flash",
   "gemini-3.6-flash",
 ];
-
-// Pricing per million tokens (as of August 2026)
-// Source: Provider pricing pages
-const PRICING = {
-  "gpt-5": { input: 2.5, output: 10.0 },
-  "gpt-5-mini": { input: 0.4, output: 1.6 },
-  "gpt-5-nano": { input: 0.1, output: 0.4 },
-  "claude-opus-4-1": { input: 15.0, output: 75.0 },
-  "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
-  "claude-haiku-4-5": { input: 0.8, output: 4.0 },
-  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
-  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
-  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
-  "gemini-3.5-flash": { input: 1.5, output: 9.0 },
-  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
-  "gemini-3.6-flash": { input: 1.5, output: 7.5 },
-};
-
-/**
- * Calculate cost for a model call
- * @param {string} model - Model name
- * @param {object} tokens - Token usage object
- * @returns {number} - Cost in USD
- */
-function calculateCost(model, tokens) {
-  const pricing = PRICING[model];
-  if (!pricing) {
-    return 0;
-  }
-
-  const inputCost = (tokens.prompt_tokens / 1_000_000) * pricing.input;
-  // Thinking tokens bill as output but are reported separately, so a reasoning
-  // model looks ~5x cheaper than it is if they are left out.
-  const outputTokens =
-    tokens.completion_tokens + (tokens.reasoning_tokens || 0);
-  const outputCost = (outputTokens / 1_000_000) * pricing.output;
-
-  return inputCost + outputCost;
-}
 
 // System prompts and helper functions are now in lib/DotaMatchProcessor.mjs and lib/DeadlockMatchProcessor.mjs
 
@@ -161,7 +123,7 @@ function parseArgs() {
 
   // Validate that all specified models are known (have pricing)
   for (const model of parsed.models) {
-    if (!PRICING[model]) {
+    if (!isPriced(model)) {
       console.error(
         `Warning: Model '${model}' does not have pricing information`,
       );
@@ -379,7 +341,9 @@ async function runEvaluation(args) {
         console.log(
           `  Tokens: ${result.usage.prompt_tokens} in / ${result.usage.completion_tokens} out`,
         );
-        console.log(`  Cost: $${cost.toFixed(4)}`);
+        console.log(
+          `  Cost: ${cost === null ? "unpriced" : `$${cost.toFixed(4)}`}`,
+        );
       } catch (err) {
         console.error(`  ✗ Failed: ${err.message}`);
         evaluation.results.push({

--- a/llm-evals/generate-eval.mjs
+++ b/llm-evals/generate-eval.mjs
@@ -1,4 +1,5 @@
 import LLMClient from "../lib/LLMClient.mjs";
+import { ANALYSIS_SCHEMA } from "../lib/analysis.mjs";
 import OpenDotaAPI from "../lib/OpenDotaAPI.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
 import NoOpCache from "./lib/NoOpCache.mjs";
@@ -42,9 +43,11 @@ const MODELS = [
   "claude-sonnet-4-5",
   "gemini-2.5-pro",
   "gemini-2.5-flash",
+  "gemini-3.5-flash",
+  "gemini-3.6-flash",
 ];
 
-// Pricing per million tokens (as of October 2025)
+// Pricing per million tokens (as of August 2026)
 // Source: Provider pricing pages
 const PRICING = {
   "gpt-5": { input: 2.5, output: 10.0 },
@@ -53,9 +56,12 @@ const PRICING = {
   "claude-opus-4-1": { input: 15.0, output: 75.0 },
   "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
   "claude-haiku-4-5": { input: 0.8, output: 4.0 },
-  "gemini-2.5-pro": { input: 1.25, output: 5.0 },
-  "gemini-2.5-flash": { input: 0.075, output: 0.3 },
-  "gemini-2.5-flash-lite": { input: 0.0375, output: 0.15 },
+  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gemini-3.5-flash": { input: 1.5, output: 9.0 },
+  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
+  "gemini-3.6-flash": { input: 1.5, output: 7.5 },
 };
 
 /**
@@ -71,7 +77,11 @@ function calculateCost(model, tokens) {
   }
 
   const inputCost = (tokens.prompt_tokens / 1_000_000) * pricing.input;
-  const outputCost = (tokens.completion_tokens / 1_000_000) * pricing.output;
+  // Thinking tokens bill as output but are reported separately, so a reasoning
+  // model looks ~5x cheaper than it is if they are left out.
+  const outputTokens =
+    tokens.completion_tokens + (tokens.reasoning_tokens || 0);
+  const outputCost = (outputTokens / 1_000_000) * pricing.output;
 
   return inputCost + outputCost;
 }
@@ -350,7 +360,7 @@ async function runEvaluation(args) {
       console.log(`\nTesting ${model}...`);
 
       try {
-        const result = await llm.call(match.prompt, model);
+        const result = await llm.call(match.prompt, model, ANALYSIS_SCHEMA);
 
         const cost = calculateCost(model, result.usage);
 

--- a/llm-evals/lib/pricing.mjs
+++ b/llm-evals/lib/pricing.mjs
@@ -1,0 +1,40 @@
+// Per million tokens, as of August 2026. Source: provider pricing pages.
+const PRICING = {
+  "gpt-5": { input: 2.5, output: 10.0 },
+  "gpt-5-mini": { input: 0.4, output: 1.6 },
+  "gpt-5-nano": { input: 0.1, output: 0.4 },
+  "claude-opus-4-1": { input: 15.0, output: 75.0 },
+  "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
+  "claude-haiku-4-5": { input: 0.8, output: 4.0 },
+  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gemini-3.5-flash": { input: 1.5, output: 9.0 },
+  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
+  "gemini-3.6-flash": { input: 1.5, output: 7.5 },
+};
+
+export function isPriced(model) {
+  return Boolean(PRICING[model]);
+}
+
+/**
+ * Cost in USD, or null when the model has no published price -- which reads
+ * differently from a genuine zero when it reaches an average.
+ */
+export function calculateCost(model, tokens) {
+  const pricing = PRICING[model];
+  if (!pricing || !tokens) {
+    return null;
+  }
+
+  // Thinking tokens bill as output. LLMClient reports them separately from
+  // completion_tokens on every provider, so the two always add.
+  const outputTokens =
+    tokens.completion_tokens + (tokens.reasoning_tokens || 0);
+
+  return (
+    (tokens.prompt_tokens / 1_000_000) * pricing.input +
+    (outputTokens / 1_000_000) * pricing.output
+  );
+}


### PR DESCRIPTION
Two related fixes to the analyst LLM path, plus a correction to the eval harness.

## Enforce the output schema

Both analysts asked for JSON and hoped. Gemini's `response_mime_type` puts the model in JSON mode but does not constrain decoding, so on the real Dota prompt `gemini-3.5-flash` emitted a duplicated closing brace on 2 of 5 calls and the retry loop absorbed it — at the cost of one run taking 72s across three attempts.

All three providers accept the same standard JSON Schema; only the field differs (`response_json_schema`, `response_format.json_schema`, `output_config.format`). With the schema attached, the same prompt parsed cleanly 5/5.

The prose `SCHEMA` block the prompt shows the model was itself invalid JSON — it carried a trailing comma, which is exactly the malformation the model then reproduced.

## Fall back when a model is out of quota

The free tier caps each Gemini model at 20 requests a day, and hitting that cap failed the analysis outright. The caps are per model, so stepping down the chain buys a fresh allowance rather than a share of one pool:

`gemini-3.6-flash` → `gemini-3.5-flash` → `gemini-2.5-flash` → `gemini-3.5-flash-lite`

Failures are now classified on two axes rather than one:

- **Retry in place** — only 5xx. A 429 asking for a 30s `retryDelay`, answered with a 300ms backoff, cannot succeed and is the one pattern here that would look like abuse.
- **Try the next model** — 429, 5xx, and 404. A model retired out from under us now degrades quality instead of taking down every model beneath it in the chain.

A rejected schema or malformed prompt still fails immediately; it would fail identically on every model.

The serving model is logged alongside token usage, since it is not always the first choice.

## Eval harness

Independent of the above. The Gemini rows were four to eight times under the real rates (`gemini-2.5-flash` listed at $0.075/$0.30 against an actual $0.30/$2.50), and cost counted only completion tokens — providers bill thinking tokens as output but report them separately, so reasoning models looked ~5x cheaper than they are.

## Verification

Schema path exercised end to end against all three providers on the real match prompt, each returning exactly the four expected keys. Error handling covered by a stubbed-`fetch` matrix:

| case | requests | behaviour |
|---|---|---|
| daily 429 | 1 | steps down, no retry |
| per-minute 429 | 1 | steps down, no hammering |
| 404 retired | 1 | steps down |
| 400 bad request | 1 | throws, no step-down |
| 503 | 3 | retried in place |

The fallback was also confirmed against a genuinely exhausted quota, not a mock. All Lambda bundles load after synth.

## Note

`ANALYSIS_MODELS` promotes `gemini-3.6-flash` ahead of the `gemini-2.5-flash` currently in production. On the two matches evaluated it was more specific and obeyed the prompt's item limits more consistently, but the ordering is a one-line change if a blind ranking disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)