### PR TITLE
Deadlock: Follow the ranks through the ranked season rewrite, and stop losing match announcements

### DIFF
--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -173,8 +173,7 @@ export async function handler(event, context) {
 
     const popularItemsTimer = createTimer("popular items loading");
     const avgBadge = await deadlockAPI.getMatchAverageBadge(matchData);
-    // Zero is the API's "every rank", which is the right pool when this match
-    // has no rank to compare against.
+    // Zero is the API's "every rank", the right pool for a match with no rank.
     const popularItemsData = await deadlockAPI.getPopularItems(
       player.hero_id,
       avgBadge ?? 0,

--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -172,12 +172,12 @@ export async function handler(event, context) {
     itemsTimer.end();
 
     const popularItemsTimer = createTimer("popular items loading");
-    const avgBadge = Math.round(
-      (matchData.average_badge_team0 + matchData.average_badge_team1) / 2,
-    );
+    const avgBadge = await deadlockAPI.getMatchAverageBadge(matchData);
+    // Zero is the API's "every rank", which is the right pool when this match
+    // has no rank to compare against.
     const popularItemsData = await deadlockAPI.getPopularItems(
       player.hero_id,
-      avgBadge,
+      avgBadge ?? 0,
     );
     popularItemsTimer.end();
 
@@ -187,6 +187,7 @@ export async function handler(event, context) {
       Number(player_id),
       itemsData,
       popularItemsData,
+      avgBadge,
     );
     compactTimer.end();
 

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -230,16 +230,15 @@ export async function handler() {
       continue;
     }
 
+    // Oldest first, so the watermark only ever steps forward over matches that
+    // were announced. Stopping at the first failure leaves the rest to the next
+    // run rather than skipping past them or re-sending what already landed.
     const newMatches = data.slice(0, seenIndex).reverse();
-    const results = [];
     for (const match of newMatches) {
-      const result = await handleMatch(match, user);
-      results.push(result);
-    }
-    const successful = results.some(({ error }) => !error);
+      const { error } = await handleMatch(match, user);
+      if (error) break;
 
-    if (successful) {
-      await updateDB(user.player_id, data[0].match_id);
+      await updateDB(user.player_id, match.match_id);
     }
   }
 

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -103,15 +103,13 @@ async function handleMatch(match, user) {
   const result = match.match_result === match.player_team ? "won" : "lost";
   const hero = constants.heroes[match.hero_id];
 
-  const matchType = [
+  const played = withArticle(
     constants.matchModes[metadata?.match_info?.match_mode],
     "Deadlock",
     constants.gameModes[metadata?.match_info?.game_mode],
     "match",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const description = `${user.name} ${result} ${withArticle(matchType)} as ${hero.name}`;
+  );
+  const description = `${user.name} ${result} ${played} as ${hero.name}`;
   const fields = [];
 
   fields.push({

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -81,15 +81,6 @@ function formatDuration(duration) {
   return parts.join(" ");
 }
 
-function formatRank(average) {
-  if (average == null) return null;
-
-  const rank = Math.floor(average / 10);
-  const subrank = average % 10;
-
-  return constants.ranks[rank] ? `${constants.ranks[rank]} ${subrank}` : null;
-}
-
 async function handleMatch(match, user) {
   console.log(`Found match: ${match.match_id}`);
 
@@ -112,8 +103,15 @@ async function handleMatch(match, user) {
   const result = match.match_result === match.player_team ? "won" : "lost";
   const hero = constants.heroes[match.hero_id];
 
-  const gameMode = metadata?.match_info?.game_mode;
-  const matchType = gameMode === 4 ? "street brawl" : "match";
+  // Reads like the Dota embed: "<mode> <game mode> match", skipping either half
+  // when there is no word for it.
+  const matchType = [
+    constants.matchModes[metadata?.match_info?.match_mode],
+    constants.gameModes[metadata?.match_info?.game_mode],
+    "match",
+  ]
+    .filter(Boolean)
+    .join(" ");
   const description = `${user.name} ${result} a Deadlock ${matchType} as ${hero.name}`;
   const fields = [];
 
@@ -141,18 +139,9 @@ async function handleMatch(match, user) {
     inline: true,
   });
 
-  // Prefer rank from metadata, fall back to match history
-  let rank = null;
-  if (metadata?.match_info) {
-    const avgBadge = Math.round(
-      (metadata.match_info.average_badge_team0 +
-        metadata.match_info.average_badge_team1) /
-        2,
-    );
-    rank = formatRank(avgBadge);
-  } else {
-    rank = formatRank(match.average_match_badge);
-  }
+  const rank = constants.formatBadge(
+    await deadlockAPI.getMatchAverageBadge(metadata?.match_info),
+  );
 
   if (rank) {
     fields.push({

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -103,16 +103,19 @@ async function handleMatch(match, user) {
   const result = match.match_result === match.player_team ? "won" : "lost";
   const hero = constants.heroes[match.hero_id];
 
-  // Reads like the Dota embed: "<mode> <game mode> match", skipping either half
-  // when there is no word for it.
+  // Reads like the Dota embed: "<mode> Deadlock <game mode> match", dropping
+  // either qualifier when there is no word for it.
   const matchType = [
     constants.matchModes[metadata?.match_info?.match_mode],
+    "Deadlock",
     constants.gameModes[metadata?.match_info?.game_mode],
     "match",
   ]
     .filter(Boolean)
     .join(" ");
-  const description = `${user.name} ${result} a Deadlock ${matchType} as ${hero.name}`;
+  // "unranked" is the only qualifier that leads, and it takes "an".
+  const article = matchType.startsWith("unranked") ? "an" : "a";
+  const description = `${user.name} ${result} ${article} ${matchType} as ${hero.name}`;
   const fields = [];
 
   fields.push({

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -228,9 +228,8 @@ export async function handler() {
       continue;
     }
 
-    // Oldest first, so the watermark only ever steps forward over matches that
-    // were announced. Stopping at the first failure leaves the rest to the next
-    // run rather than skipping past them or re-sending what already landed.
+    // Oldest first, so stopping at the first failure leaves the watermark on the
+    // last match that was announced and the rest to the next run.
     const newMatches = data.slice(0, seenIndex).reverse();
     for (const match of newMatches) {
       const { error } = await handleMatch(match, user);

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -11,7 +11,7 @@ const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
 import Discord from "../lib/Discord.mjs";
-import { simpleGet } from "../lib/utils.mjs";
+import { simpleGet, withArticle } from "../lib/utils.mjs";
 import * as constants from "../lib/DeadlockConstants.mjs";
 import DeadlockAPI from "../lib/DeadlockAPI.mjs";
 import cache from "../lib/cache.mjs";
@@ -103,8 +103,6 @@ async function handleMatch(match, user) {
   const result = match.match_result === match.player_team ? "won" : "lost";
   const hero = constants.heroes[match.hero_id];
 
-  // Reads like the Dota embed: "<mode> Deadlock <game mode> match", dropping
-  // either qualifier when there is no word for it.
   const matchType = [
     constants.matchModes[metadata?.match_info?.match_mode],
     "Deadlock",
@@ -113,9 +111,7 @@ async function handleMatch(match, user) {
   ]
     .filter(Boolean)
     .join(" ");
-  // "unranked" is the only qualifier that leads, and it takes "an".
-  const article = matchType.startsWith("unranked") ? "an" : "a";
-  const description = `${user.name} ${result} ${article} ${matchType} as ${hero.name}`;
+  const description = `${user.name} ${result} ${withArticle(matchType)} as ${hero.name}`;
   const fields = [];
 
   fields.push({

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -199,10 +199,13 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
 
   const thumbnail_url = `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`;
 
-  const matchType = [skill && `${skill} skill`, lobby, gameMode, "match"]
-    .filter(Boolean)
-    .join(" ");
-  const description = `${user.personaname} ${result} ${withArticle(matchType)} as ${hero.name}`;
+  const played = withArticle(
+    skill && `${skill} skill`,
+    lobby,
+    gameMode,
+    "match",
+  );
+  const description = `${user.personaname} ${result} ${played} as ${hero.name}`;
   const embed = {
     author: {
       name: user.personaname,

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -10,6 +10,7 @@ import DotaConstants from "../lib/DotaConstants.mjs";
 import cache from "../lib/cache.mjs";
 import secrets from "../lib/secrets.mjs";
 import tables from "../lib/tables.mjs";
+import { withArticle } from "../lib/utils.mjs";
 
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
@@ -201,11 +202,7 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   const matchType = [skill && `${skill} skill`, lobby, gameMode, "match"]
     .filter(Boolean)
     .join(" ");
-  // Whichever qualifier survives leads the phrase, and "An Unranked match" and
-  // "an All Pick match" both come up. No mode starts with a sounded "u", so the
-  // vowel is enough to go on.
-  const article = /^[aeiou]/i.test(matchType) ? "an" : "a";
-  const description = `${user.personaname} ${result} ${article} ${matchType} as ${hero.name}`;
+  const description = `${user.personaname} ${result} ${withArticle(matchType)} as ${hero.name}`;
   const embed = {
     author: {
       name: user.personaname,

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -289,15 +289,14 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
 }
 
 // Resolves each user's newest announced match, which is what their watermark may
-// advance to. A user whose first match failed to send is absent.
+// advance to, and is absent when their first match failed to send. Their matches
+// are already oldest first, so a failure stops that user where Discord did.
 async function sendDiscordMessages(users, matches, config) {
   const queue = [];
 
   Object.keys(users).forEach((steamID) => {
     const user = users[steamID];
 
-    // Already oldest first, so stopping at a failure leaves the watermark on the
-    // last match that reached Discord.
     user.matches.forEach((matchID) => {
       queue.push({
         steamID,

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -198,14 +198,14 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
 
   const thumbnail_url = `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`;
 
-  let description = `${user.personaname} ${result} a `;
-  if (skill) {
-    description += `${skill} skill `;
-  }
-  if (lobby) {
-    description += `${lobby} `;
-  }
-  description += `${gameMode} match as ${hero.name}`;
+  const matchType = [skill && `${skill} skill`, lobby, gameMode, "match"]
+    .filter(Boolean)
+    .join(" ");
+  // Whichever qualifier survives leads the phrase, and "An Unranked match" and
+  // "an All Pick match" both come up. No mode starts with a sounded "u", so the
+  // vowel is enough to go on.
+  const article = /^[aeiou]/i.test(matchType) ? "an" : "a";
+  const description = `${user.personaname} ${result} ${article} ${matchType} as ${hero.name}`;
   const embed = {
     author: {
       name: user.personaname,

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -285,38 +285,66 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   return { embed, components };
 }
 
+// Resolves each user's newest announced match, which is what their watermark may
+// advance to. A user whose first match failed to send is absent.
 async function sendDiscordMessages(users, matches, config) {
-  const messages = [];
+  const queue = [];
 
   Object.keys(users).forEach((steamID) => {
     const user = users[steamID];
 
+    // Already oldest first, so stopping at a failure leaves the watermark on the
+    // last match that reached Discord.
     user.matches.forEach((matchID) => {
-      const message = createDiscordMessageForMatch(
+      queue.push({
         steamID,
-        user,
         matchID,
-        matches[matchID],
-        config,
-      );
-
-      if (message) {
-        messages.push(message);
-      }
+        message: createDiscordMessageForMatch(
+          steamID,
+          user,
+          matchID,
+          matches[matchID],
+          config,
+        ),
+      });
     });
   });
+
+  const announced = {};
+  const stalled = new Set();
 
   // Sequential on purpose. Promise.all here would post the embeds in whatever order
   // Discord answers, and would drop the spacing that keeps a burst of matches under
   // the rate limit.
-  for (const { embed, components } of messages) {
-    await discord.sendEmbed(embed, "results", components);
+  for (const { steamID, matchID, message } of queue) {
+    if (stalled.has(steamID)) {
+      continue;
+    }
+
+    if (message) {
+      const { error } = await discord.sendEmbed(
+        message.embed,
+        "results",
+        message.components,
+      );
+
+      if (error) {
+        stalled.add(steamID);
+        continue;
+      }
+    }
+
+    // A match with no embed to build still counts as handled -- retrying it would
+    // come up empty every poll and pin the watermark forever.
+    announced[steamID] = matchID;
   }
+
+  return announced;
 }
 
-async function updateDB(users) {
+async function updateDB(users, announced) {
   await Promise.all(
-    Object.keys(users).map(async (steamID) => {
+    Object.keys(announced).map(async (steamID) => {
       const user = users[steamID];
 
       const params = {
@@ -327,7 +355,7 @@ async function updateDB(users) {
         UpdateExpression:
           "SET last_matchID = :last_matchID, updated_at = :updated_at, dotaname = :dotaname",
         ExpressionAttributeValues: {
-          ":last_matchID": Math.max(...user.matches),
+          ":last_matchID": announced[steamID],
           ":updated_at": Date.now(),
           ":dotaname": user.personaname,
         },
@@ -351,8 +379,8 @@ export async function handler() {
   const { users, matches } = await collectNewMatches(dbUsers);
   await loadPlayers(users);
   await loadMatches(users, matches);
-  await sendDiscordMessages(users, matches, config);
-  await updateDB(users);
+  const announced = await sendDiscordMessages(users, matches, config);
+  await updateDB(users, announced);
 
   return { message: "Done" };
 }

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -222,8 +222,8 @@ class DeadlockAPI {
 
     const cacheKey = `ranks:${ids.join(",")}`;
 
-    try {
-      if (this.#cache) {
+    if (this.#cache) {
+      try {
         const cached = await this.#cache.get(
           PLAYER_RANKS_CACHE_NAMESPACE,
           cacheKey,
@@ -233,8 +233,13 @@ class DeadlockAPI {
           return typeof cached === "string" ? JSON.parse(cached) : cached;
         }
         console.log(`Cache miss for player ranks (${ids.length} players)`);
+      } catch (err) {
+        // Unreadable is no worse than absent, and the API can still answer.
+        console.error(`Failed to read cached player ranks: ${err}`);
       }
+    }
 
+    try {
       const res = await fetch(
         `${API_PREFIX}players/mmr?account_ids=${ids.join(",")}`,
         { signal: AbortSignal.timeout(5000) },

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -1,8 +1,14 @@
+import { averageBadge } from "./DeadlockConstants.mjs";
+
 const SEVEN_DAYS = 7 * 24 * 60 * 60;
 const ONE_DAY = 24 * 60 * 60;
 const API_PREFIX = "https://api.deadlock-api.com/v1/";
 const CACHE_NAMESPACE = "deadlock-matches";
 const POPULAR_ITEMS_CACHE_NAMESPACE = "deadlock-popular-items";
+const PLAYER_RANKS_CACHE_NAMESPACE = "deadlock-player-ranks";
+
+/** `match_mode` value for the ranked queue the July 2026 season introduced. */
+const RANKED_MATCH_MODE = 4;
 
 /**
  * Deadlock API client with optional caching support.
@@ -200,6 +206,98 @@ class DeadlockAPI {
       console.error(`Failed to fetch popular items: ${err}`);
       return null;
     }
+  }
+
+  /**
+   * The rank each of these players carries from their own latest ranked match.
+   *
+   * Says nothing about any particular match. Players who have never finished
+   * placement are omitted, so this is usually shorter than what went in.
+   *
+   * `players/mmr` is deprecated in favour of the single-player `players/{id}/rank`,
+   * but it is the only batched form, and a rank field on an embed is not worth
+   * twelve requests.
+   *
+   * @private
+   */
+  async #playerBadges(accountIds) {
+    const ids = accountIds.filter((id) => id > 0).sort();
+    if (!ids.length) return [];
+
+    const cacheKey = `ranks:${ids.join(",")}`;
+
+    if (this.#cache) {
+      const cached = await this.#cache.get(
+        PLAYER_RANKS_CACHE_NAMESPACE,
+        cacheKey,
+      );
+      if (cached) {
+        console.log(`Cache hit for player ranks (${ids.length} players)`);
+        return typeof cached === "string" ? JSON.parse(cached) : cached;
+      }
+      console.log(`Cache miss for player ranks (${ids.length} players)`);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const res = await fetch(
+        `${API_PREFIX}players/mmr?account_ids=${ids.join(",")}`,
+        { signal: controller.signal },
+      );
+
+      if (!res.ok) {
+        console.error(`Failed to fetch player ranks: ${res.status}`);
+        return [];
+      }
+
+      const badges = (await res.json())
+        .map((player) => player.rank)
+        .filter(Boolean);
+
+      if (this.#cache) {
+        await this.#cache.set(
+          PLAYER_RANKS_CACHE_NAMESPACE,
+          cacheKey,
+          JSON.stringify(badges),
+          ONE_DAY,
+        );
+      }
+
+      return badges;
+    } catch (err) {
+      console.error(`Failed to fetch player ranks: ${err}`);
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Average badge of the players in a match, or null when too few are ranked.
+   *
+   * Valve stopped populating `average_badge_team0`/`average_badge_team1` with the
+   * July 2026 season -- both are now always zero -- so a ranked match is averaged
+   * from the per-player ranks it carries, and an unranked one, having no rank of
+   * its own to report, falls back to what its players are ranked elsewhere.
+   *
+   * @param {Object} matchInfo - `match_info` from match metadata
+   * @returns {Promise<number|null>} Badge as `tier * 10 + subrank`
+   */
+  async getMatchAverageBadge(matchInfo) {
+    const players = matchInfo?.players;
+    if (!players?.length) return null;
+
+    if (matchInfo.match_mode === RANKED_MATCH_MODE) {
+      return averageBadge(
+        players.map((player) => player.player_rank_data?.initial_display_rank),
+      );
+    }
+
+    return averageBadge(
+      await this.#playerBadges(players.map((player) => player.account_id)),
+    );
   }
 }
 

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -222,25 +222,22 @@ class DeadlockAPI {
 
     const cacheKey = `ranks:${ids.join(",")}`;
 
-    if (this.#cache) {
-      const cached = await this.#cache.get(
-        PLAYER_RANKS_CACHE_NAMESPACE,
-        cacheKey,
-      );
-      if (cached) {
-        console.log(`Cache hit for player ranks (${ids.length} players)`);
-        return typeof cached === "string" ? JSON.parse(cached) : cached;
-      }
-      console.log(`Cache miss for player ranks (${ids.length} players)`);
-    }
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-
     try {
+      if (this.#cache) {
+        const cached = await this.#cache.get(
+          PLAYER_RANKS_CACHE_NAMESPACE,
+          cacheKey,
+        );
+        if (cached) {
+          console.log(`Cache hit for player ranks (${ids.length} players)`);
+          return typeof cached === "string" ? JSON.parse(cached) : cached;
+        }
+        console.log(`Cache miss for player ranks (${ids.length} players)`);
+      }
+
       const res = await fetch(
         `${API_PREFIX}players/mmr?account_ids=${ids.join(",")}`,
-        { signal: controller.signal },
+        { signal: AbortSignal.timeout(5000) },
       );
 
       if (!res.ok) {
@@ -253,20 +250,23 @@ class DeadlockAPI {
         .filter(Boolean);
 
       if (this.#cache) {
-        await this.#cache.set(
-          PLAYER_RANKS_CACHE_NAMESPACE,
-          cacheKey,
-          JSON.stringify(badges),
-          ONE_DAY,
-        );
+        // Failing to store them is no reason to discard them.
+        await this.#cache
+          .set(
+            PLAYER_RANKS_CACHE_NAMESPACE,
+            cacheKey,
+            JSON.stringify(badges),
+            ONE_DAY,
+          )
+          .catch((err) =>
+            console.error(`Failed to cache player ranks: ${err}`),
+          );
       }
 
       return badges;
     } catch (err) {
       console.error(`Failed to fetch player ranks: ${err}`);
       return [];
-    } finally {
-      clearTimeout(timeout);
     }
   }
 
@@ -279,9 +279,10 @@ class DeadlockAPI {
     if (!players?.length) return null;
 
     if (matchInfo.match_mode === RANKED_MATCH_MODE) {
-      return averageBadge(
+      const badge = averageBadge(
         players.map((player) => player.player_rank_data?.initial_display_rank),
       );
+      if (badge) return badge;
     }
 
     return averageBadge(

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -7,7 +7,6 @@ const CACHE_NAMESPACE = "deadlock-matches";
 const POPULAR_ITEMS_CACHE_NAMESPACE = "deadlock-popular-items";
 const PLAYER_RANKS_CACHE_NAMESPACE = "deadlock-player-ranks";
 
-/** `match_mode` value for the ranked queue the July 2026 season introduced. */
 const RANKED_MATCH_MODE = 4;
 
 /**
@@ -209,14 +208,11 @@ class DeadlockAPI {
   }
 
   /**
-   * The rank each of these players carries from their own latest ranked match.
-   *
-   * Says nothing about any particular match. Players who have never finished
-   * placement are omitted, so this is usually shorter than what went in.
+   * The rank each player carries from their own latest ranked match, so players
+   * still in placement come back missing rather than zero.
    *
    * `players/mmr` is deprecated in favour of the single-player `players/{id}/rank`,
-   * but it is the only batched form, and a rank field on an embed is not worth
-   * twelve requests.
+   * but it is the only batched form, and a rank field is not worth twelve requests.
    *
    * @private
    */
@@ -275,12 +271,9 @@ class DeadlockAPI {
   }
 
   /**
-   * Average badge of the players in a match, or null when too few are ranked.
-   *
-   * Valve stopped populating `average_badge_team0`/`average_badge_team1` with the
-   * July 2026 season -- both are now always zero -- so a ranked match is averaged
-   * from the per-player ranks it carries, and an unranked one, having no rank of
-   * its own to report, falls back to what its players are ranked elsewhere.
+   * `average_badge_team0`/`average_badge_team1` have read zero since the July
+   * 2026 season, so a ranked match averages the per-player ranks it carries and
+   * an unranked one, having no rank of its own, borrows its players' standing.
    *
    * @param {Object} matchInfo - `match_info` from match metadata
    * @returns {Promise<number|null>} Badge as `tier * 10 + subrank`

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -271,9 +271,9 @@ class DeadlockAPI {
   }
 
   /**
-   * `average_badge_team0`/`average_badge_team1` have read zero since the July
-   * 2026 season, so a ranked match averages the per-player ranks it carries and
-   * an unranked one, having no rank of its own, borrows its players' standing.
+   * `average_badge_team0`/`average_badge_team1` always read zero, so a ranked
+   * match averages the per-player ranks it carries, and an unranked one, having
+   * no rank of its own, borrows its players' standing.
    *
    * @param {Object} matchInfo - `match_info` from match metadata
    * @returns {Promise<number|null>} Badge as `tier * 10 + subrank`

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -217,7 +217,7 @@ class DeadlockAPI {
    * @private
    */
   async #playerBadges(accountIds) {
-    const ids = accountIds.filter((id) => id > 0).sort();
+    const ids = accountIds.filter((id) => id > 0).sort((a, b) => a - b);
     if (!ids.length) return [];
 
     const cacheKey = `ranks:${ids.join(",")}`;

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -62,7 +62,6 @@ class DeadlockAPI {
   async getMatchMetadata(matchId, { skipCache = false } = {}) {
     const cacheKey = `metadata:${matchId}`;
 
-    // Check cache first (unless skipped)
     if (!skipCache && this.#cache) {
       const cachedMetadata = await this.#cache.get(CACHE_NAMESPACE, cacheKey);
       if (cachedMetadata) {
@@ -74,12 +73,10 @@ class DeadlockAPI {
       console.log(`Cache miss for match metadata ${matchId}`);
     }
 
-    // Fetch from API
     try {
       const data = await this.#fetchMatchMetadataFromAPI(matchId);
       if (!data) return null;
 
-      // Cache the metadata for 7 days (unless skipped)
       if (!skipCache && this.#cache) {
         await this.#cache.set(
           CACHE_NAMESPACE,
@@ -105,7 +102,6 @@ class DeadlockAPI {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
 
-    // Calculate 7 days ago in Unix timestamp
     const sevenDaysAgo = Math.floor(Date.now() / 1000) - 7 * 24 * 60 * 60;
 
     const url = `${API_PREFIX}analytics/item-stats?hero_ids=${heroId}&min_average_badge=${minBadge}&min_unix_timestamp=${sevenDaysAgo}&min_matches=${minMatches}`;
@@ -145,7 +141,6 @@ class DeadlockAPI {
   ) {
     const cacheKey = `popular-items:hero-${heroId}:badge-${minBadge}:minMatches-${minMatches}:v2`;
 
-    // Check cache first (unless skipped)
     if (!skipCache && this.#cache) {
       const cachedItems = await this.#cache.get(
         POPULAR_ITEMS_CACHE_NAMESPACE,
@@ -164,8 +159,8 @@ class DeadlockAPI {
       );
     }
 
-    // Fetch from API (filtering by minMatches is done server-side)
     try {
+      // minMatches is applied server-side, so nothing filters on it here.
       const data = await this.#fetchPopularItemsFromAPI(
         heroId,
         minBadge,
@@ -173,7 +168,6 @@ class DeadlockAPI {
       );
       if (!data) return null;
 
-      // Calculate win rate and sort by win rate (descending)
       const itemsWithWinRate = Array.isArray(data)
         ? data.map((item) => ({
             ...item,
@@ -184,12 +178,10 @@ class DeadlockAPI {
           }))
         : [];
 
-      // Sort by win rate (descending)
       const sortedItems = itemsWithWinRate.sort(
         (a, b) => b.win_rate - a.win_rate,
       );
 
-      // Cache the popular items for 24 hours (unless skipped)
       if (!skipCache && this.#cache) {
         await this.#cache.set(
           POPULAR_ITEMS_CACHE_NAMESPACE,
@@ -296,5 +288,4 @@ class DeadlockAPI {
   }
 }
 
-// Export only the class
 export default DeadlockAPI;

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -271,10 +271,6 @@ class DeadlockAPI {
   }
 
   /**
-   * `average_badge_team0`/`average_badge_team1` always read zero, so a ranked
-   * match averages the per-player ranks it carries, and an unranked one, having
-   * no rank of its own, borrows its players' standing.
-   *
    * @param {Object} matchInfo - `match_info` from match metadata
    * @returns {Promise<number|null>} Badge as `tier * 10 + subrank`
    */

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -262,12 +262,15 @@ export const gameModes = {
 };
 
 /**
+ * Tier 0 is Obscurus, which has no subranks and means unranked, so it formats
+ * as nothing rather than as a rank.
+ *
  * @param {number|null} badge - `tier * 10 + subrank`
  * @returns {string|null} e.g. "Ritualist 1", or null when there is no rank
  */
 export function formatBadge(badge) {
-  if (!badge) return null;
-
   const tier = Math.floor(badge / 10);
-  return ranks[tier] ? `${ranks[tier]} ${badge % 10}` : null;
+  if (!tier || !ranks[tier]) return null;
+
+  return `${ranks[tier]} ${badge % 10}`;
 }

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -214,8 +214,6 @@ export const heroes = {
   },
 };
 
-// Indexed by tier. The July 2026 season renamed tiers 3 through 7, so older
-// names elsewhere are stale: <https://api.deadlock-api.com/v1/assets/ranks>
 export const ranks = [
   "Obscurus",
   "Initiate",

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -235,8 +235,8 @@ const badgeValues = ranks.flatMap((_, tier) =>
 
 /**
  * Badges are `tier * 10 + subrank` with subranks 1 to 6, so they are not a
- * number line -- the arithmetic mean of 51 and 66 is 58, a rank nobody holds.
- * Averaging index positions lands on a real one, as DotaConstants does.
+ * number line: the arithmetic mean of 51 and 65 is 58, a rank nobody holds.
+ * Averaging index positions lands on a real one, as the Dota handler does.
  *
  * @param {Array<number|null|undefined>} badges
  * @returns {number|null} Null unless at least two badges are known
@@ -262,8 +262,8 @@ export const gameModes = {
 };
 
 /**
- * Tier 0 is Obscurus, which has no subranks and means unranked, so it formats
- * as nothing rather than as a rank.
+ * Tier 0 is Obscurus, which the rank assets give no subranks: it means unranked,
+ * so it formats as nothing rather than as a rank.
  *
  * @param {number|null} badge - `tier * 10 + subrank`
  * @returns {string|null} e.g. "Ritualist 1", or null when there is no rank

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -244,7 +244,7 @@ export const ranks = [
  * cannot occur. Averaging index positions in this array instead keeps the result
  * on a real rank, the same trick DotaConstants.rankTierValues exists for.
  */
-export const badgeValues = ranks.flatMap((_, tier) =>
+const badgeValues = ranks.flatMap((_, tier) =>
   tier === 0 ? [] : [1, 2, 3, 4, 5, 6].map((subrank) => tier * 10 + subrank),
 );
 

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -214,13 +214,8 @@ export const heroes = {
   },
 };
 
-/**
- * Indexed by tier, so a badge of `tier * 10 + subrank` reads as `ranks[tier]`.
- *
- * The July 30 2026 ranked season renamed tiers 3 through 7 without changing
- * how many there are, which is why the shift is invisible in the badge numbers.
- * Authoritative list: <https://api.deadlock-api.com/v1/assets/ranks>
- */
+// Indexed by tier. The July 2026 season renamed tiers 3 through 7, so older
+// names elsewhere are stale: <https://api.deadlock-api.com/v1/assets/ranks>
 export const ranks = [
   "Obscurus",
   "Initiate",
@@ -236,27 +231,17 @@ export const ranks = [
   "Eternus",
 ];
 
-/**
- * Every badge that exists, lowest to highest, excluding the unranked zero.
- *
- * Badges are base-10 encoded with subranks running 1 to 6, so the values are not
- * a number line: averaging 51 and 66 arithmetically gives 58, a subrank that
- * cannot occur. Averaging index positions in this array instead keeps the result
- * on a real rank, the same trick DotaConstants.rankTierValues exists for.
- */
 const badgeValues = ranks.flatMap((_, tier) =>
   tier === 0 ? [] : [1, 2, 3, 4, 5, 6].map((subrank) => tier * 10 + subrank),
 );
 
 /**
- * Mean of the badges we actually have, or null.
- *
- * Players missing a rank drop out rather than dragging the mean toward zero, and
- * a lone badge is not worth calling a match average -- the same bar the Dota
- * handler sets before it shows a tier.
+ * Badges are `tier * 10 + subrank` with subranks 1 to 6, so they are not a
+ * number line -- the arithmetic mean of 51 and 66 is 58, a rank nobody holds.
+ * Averaging index positions lands on a real one, as DotaConstants does.
  *
  * @param {Array<number|null|undefined>} badges
- * @returns {number|null} A badge that exists, as `tier * 10 + subrank`
+ * @returns {number|null} Null unless at least two badges are known
  */
 export function averageBadge(badges) {
   const indexes = badges
@@ -268,13 +253,12 @@ export function averageBadge(badges) {
   return badgeValues[Math.round(mean)];
 }
 
-/** Indexed by `match_mode`; only the queues a tracked player can end up in. */
 export const matchModes = {
   1: "unranked",
   4: "ranked",
 };
 
-/** Indexed by `game_mode`. Normal has no adjective worth printing. */
+// Only the modes worth naming; normal reads as a plain "match".
 export const gameModes = {
   4: "street brawl",
 };

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -214,17 +214,78 @@ export const heroes = {
   },
 };
 
+/**
+ * Indexed by tier, so a badge of `tier * 10 + subrank` reads as `ranks[tier]`.
+ *
+ * The July 30 2026 ranked season renamed tiers 3 through 7 without changing
+ * how many there are, which is why the shift is invisible in the badge numbers.
+ * Authoritative list: <https://api.deadlock-api.com/v1/assets/ranks>
+ */
 export const ranks = [
   "Obscurus",
   "Initiate",
   "Seeker",
-  "Alchemist",
-  "Arcanist",
+  "Acolyte",
+  "Sentinel",
+  "Mystic",
   "Ritualist",
   "Emissary",
-  "Archon",
   "Oracle",
   "Phantom",
   "Ascendant",
   "Eternus",
 ];
+
+/**
+ * Every badge that exists, lowest to highest, excluding the unranked zero.
+ *
+ * Badges are base-10 encoded with subranks running 1 to 6, so the values are not
+ * a number line: averaging 51 and 66 arithmetically gives 58, a subrank that
+ * cannot occur. Averaging index positions in this array instead keeps the result
+ * on a real rank, the same trick DotaConstants.rankTierValues exists for.
+ */
+export const badgeValues = ranks.flatMap((_, tier) =>
+  tier === 0 ? [] : [1, 2, 3, 4, 5, 6].map((subrank) => tier * 10 + subrank),
+);
+
+/**
+ * Mean of the badges we actually have, or null.
+ *
+ * Players missing a rank drop out rather than dragging the mean toward zero, and
+ * a lone badge is not worth calling a match average -- the same bar the Dota
+ * handler sets before it shows a tier.
+ *
+ * @param {Array<number|null|undefined>} badges
+ * @returns {number|null} A badge that exists, as `tier * 10 + subrank`
+ */
+export function averageBadge(badges) {
+  const indexes = badges
+    .map((badge) => badgeValues.indexOf(badge))
+    .filter((index) => index >= 0);
+  if (indexes.length < 2) return null;
+
+  const mean = indexes.reduce((sum, index) => sum + index, 0) / indexes.length;
+  return badgeValues[Math.round(mean)];
+}
+
+/** Indexed by `match_mode`; only the queues a tracked player can end up in. */
+export const matchModes = {
+  1: "unranked",
+  4: "ranked",
+};
+
+/** Indexed by `game_mode`. Normal has no adjective worth printing. */
+export const gameModes = {
+  4: "street brawl",
+};
+
+/**
+ * @param {number|null} badge - `tier * 10 + subrank`
+ * @returns {string|null} e.g. "Ritualist 1", or null when there is no rank
+ */
+export function formatBadge(badge) {
+  if (!badge) return null;
+
+  const tier = Math.floor(badge / 10);
+  return ranks[tier] ? `${ranks[tier]} ${badge % 10}` : null;
+}

--- a/lib/DeadlockMatchProcessor.mjs
+++ b/lib/DeadlockMatchProcessor.mjs
@@ -584,28 +584,6 @@ function preparePlayer(
   };
 }
 
-function formatRank(rankValue) {
-  if (!rankValue) return "Unranked";
-
-  let tier = Math.floor(rankValue / 10);
-  let level = rankValue % 10;
-
-  // Handle edge case: level 0 means previous tier's level 6
-  if (level === 0 && tier > 0) {
-    tier -= 1;
-    level = 6;
-  }
-
-  // Handle levels > 6 by promoting to next tier (ranks only go 1-6)
-  if (level > 6) {
-    tier += 1;
-    level -= 6;
-  }
-
-  const tierName = DeadlockConstants.ranks[tier];
-  return tierName ? `${tierName} ${level}` : "Unknown";
-}
-
 function calculateDistance(pos1, pos2) {
   const dx = pos1.x - pos2.x;
   const dy = pos1.y - pos2.y;
@@ -795,12 +773,9 @@ export function generateCompactMatch(
   focusPlayerId,
   itemsData,
   popularItemsData = null,
+  averageBadge = null,
 ) {
-  // Calculate average match rank
-  const avgRank = Math.round(
-    (matchData.average_badge_team0 + matchData.average_badge_team1) / 2,
-  );
-  const matchRank = formatRank(avgRank);
+  const matchRank = DeadlockConstants.formatBadge(averageBadge) ?? "Unranked";
 
   // Build custom stats lookup from definitions
   const customStatsLookup = {};
@@ -1238,9 +1213,10 @@ Refer to the player by the provided player name.
 Return ONLY one JSON object that matches the schema exactly-no extra keys, no surrounding text or code fences.
 
 TEAMS
-- Team 0: The Amber Hand
-- Team 1: The Sapphire Flame
+- Team 0: The Hidden King
+- Team 1: The Archmother
 - Always refer to teams by their names, not "Team 0" or "Team 1"
+- Do not call them The Amber Hand or The Sapphire Flame; those names were retired
 
 MATCH OUTCOME
 - The winning_team field (0 or 1) indicates which team won the match
@@ -1251,7 +1227,7 @@ MATCH DATA FORMAT
 - timeline: Unified chronological log of all match events including hero kills (killer/victim), objectives destroyed (owning_team/objective_id/damage), and Mid Boss kills (team). Use this to understand match flow and correlate events.
 - Objective events have owning_team (which team owned and lost this objective), creep_damage (damage from lane creeps), and player_damage (damage from heroes).
 - High player_damage indicates active fighting over the objective; high creep_damage with low player_damage suggests the objective was ignored/undefended.
-- All team values in the data use numeric IDs: 0 = Amber Hand, 1 = Sapphire Flame
+- All team values in the data use numeric IDs: 0 = The Hidden King, 1 = The Archmother
 
 CONSTRAINTS
 - Use only data explicitly present in JSON; never invent, infer, or speculate on missing values.

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -36,6 +36,12 @@ export async function simpleGet(url, { qs, headers, timeout } = {}) {
   }
 }
 
+// Both match handlers describe "a <mode> match". No mode or lobby name starts
+// with a sounded "u" ("a user"), so the leading vowel is enough to go on.
+export function withArticle(phrase) {
+  return `${/^[aeiou]/i.test(phrase) ? "an" : "a"} ${phrase}`;
+}
+
 export async function loadFeedData(key) {
   try {
     const params = {

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -36,9 +36,12 @@ export async function simpleGet(url, { qs, headers, timeout } = {}) {
   }
 }
 
-// Both match handlers describe "a <mode> match". No mode or lobby name starts
-// with a sounded "u" ("a user"), so the leading vowel is enough to go on.
-export function withArticle(phrase) {
+// Both match handlers describe "a <mode> match" from parts that may be absent.
+// No mode or lobby name starts with a sounded "u" ("a user"), so the leading
+// vowel is enough to go on.
+export function withArticle(...parts) {
+  const phrase = parts.filter(Boolean).join(" ");
+
   return `${/^[aeiou]/i.test(phrase) ? "an" : "a"} ${phrase}`;
 }
 

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -36,9 +36,8 @@ export async function simpleGet(url, { qs, headers, timeout } = {}) {
   }
 }
 
-// Both match handlers describe "a <mode> match" from parts that may be absent.
-// No mode or lobby name starts with a sounded "u" ("a user"), so the leading
-// vowel is enough to go on.
+// Nothing in either game's mode and lobby tables starts with a sounded "u",
+// which is where picking the article by leading vowel would break ("a user").
 export function withArticle(...parts) {
   const phrase = parts.filter(Boolean).join(" ");
 

--- a/llm-evals/generate-eval.mjs
+++ b/llm-evals/generate-eval.mjs
@@ -243,6 +243,8 @@ async function generateDeadlockPrompt(matchId, accountId, playerName) {
     matchData,
     Number(accountId),
     itemsData,
+    null,
+    await deadlockAPI.getMatchAverageBadge(matchData),
   );
 
   if (!compactMatch) {

--- a/llm-evals/test-prompt-generation.mjs
+++ b/llm-evals/test-prompt-generation.mjs
@@ -201,6 +201,8 @@ async function generateDeadlockPrompt(matchId, accountId, playerName = null) {
     matchData,
     Number(accountId),
     itemsData,
+    null,
+    await deadlockAPI.getMatchAverageBadge(matchData),
   );
   console.log(`✓ Generated compact match data`);
 


### PR DESCRIPTION
Started as the Deadlock ranked-season breakage; grew to cover the match descriptions and two watermark bugs found on the way.

## 1. Deadlock rank data moved

Valve's July 30 matchmaking update split Deadlock into Standard and Ranked queues. `average_badge_team0`/`average_badge_team1` are now **always zero** and the match-history `average_match_badge` is gone. Everything downstream read those:

- Every result embed since July 30 posted **`rank: Obscurus 0`**.
- The analyst was told every match was `Unranked`, and asked the item-stats API for `min_average_badge=0` — an all-ranks pool (44,538 matches for the hero I checked, vs 2,533 at badge 80).
- Rank tiers 3–7 were renamed, so badge 31 read "Alchemist 1" instead of "Acolyte 1".
- The analyst prompt still named the teams **The Amber Hand** and **The Sapphire Flame**, retired back in February.

A ranked match carries per-player ranks in its metadata, so its average costs no extra request. An unranked match has no rank of its own; its players' standing ranks come from one batched lookup, cached for a day. The field is dropped when fewer than two players are ranked — which is common, since the season is young and the endpoint omits anyone still in placement.

**Averaging:** badges are `tier * 10 + subrank` with subranks 1–6, so they are not a number line. The arithmetic mean of 51, 54 and 73 is 59 — "Mystic 9", a rank nobody holds. They average by index position instead, which is what `DotaConstants.rankTierValues` exists for.

## 2. Match descriptions

Both handlers now read "**an** unranked Deadlock match" / "**an** All Pick match". The article was hardcoded to `"a"`, so Dota has been announcing "a All Pick match" whenever skill and lobby were both absent; the same assembly also drops a game mode missing from the map, which used to reach Discord as the literal "a undefined match". One shared `withArticle` helper, since the two handlers had drifted to different rules.

## 3. Watermarks advanced over matches that were never announced

Two variants of one bug, both silent — nothing throws, the error metric stays flat, and the only symptom is a match that never got announced.

- **Deadlock** advanced to the newest match if *any* send in the run succeeded. A user with three new matches whose middle send failed lost that match permanently.
- **Dota** ignored `sendEmbed`'s return value entirely, so the watermark advanced whether or not Discord received anything.

Both now advance only to a user's newest *announced* match, per user. A match whose embed cannot be built still counts as handled — retrying it would come up empty every poll and pin the watermark forever.

## 4. Cache failures no longer cost more than they should

A cache write failure discarded ranks already fetched, and a read failure escaped the method entirely, taking down every user still queued rather than dropping one embed field.

## Verified

Against live matches, both modes:

| match | mode | description | rank field |
|---|---|---|---|
| `98141596` | Standard | an unranked Deadlock match | Ritualist 1 |
| `98141692` | Ranked | a ranked Deadlock match | Acolyte 1 |

The ranked figure reproduces the API's own reported average. Rank names check out tier-for-tier against `/v1/assets/ranks`, and the mode ordinals against the OpenAPI enums. Failure paths were exercised with an injected throwing cache and stripped rank data; watermark semantics were tested across success, mid-run failure, first-match failure, per-user isolation, and unbuildable embeds.

**Not verified:** neither watermark change has been exercised against a real Discord send failure in production — the logic was tested in isolation. Forcing one means pointing the results channel at a bad ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)