### PR TITLE
Repo: Add JSDoc type checking to the handlers and lib

### DIFF
--- a/handlers/DeadlockAnalyst.mjs
+++ b/handlers/DeadlockAnalyst.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -29,6 +31,7 @@ const cacheNamespace = "deadlock-ai-analyzer";
 
 const environment = await secrets();
 
+/** @param {string} operationName */
 function createTimer(operationName) {
   const start = Date.now();
   console.log(`Starting ${operationName}...`);
@@ -40,6 +43,10 @@ function createTimer(operationName) {
   };
 }
 
+/**
+ * @param {string|number} player_id
+ * @returns {Promise<string|null>}
+ */
 async function getPlayerName(player_id) {
   try {
     const result = await docClient.send(
@@ -66,6 +73,10 @@ const llm = new LLMClient({
   gemini: environment.gemini.apikey,
 });
 
+/**
+ * @param {any} event the interaction payload relayed by the webhook handler
+ * @param {any} context
+ */
 export async function handler(event, context) {
   const {
     application_id,
@@ -137,7 +148,7 @@ export async function handler(event, context) {
     const matchData = rawMatchData.match_info;
 
     const player = matchData.players.find(
-      (p) => p.account_id === Number(player_id),
+      (/** @type {any} */ p) => p.account_id === Number(player_id),
     );
 
     if (!player) {
@@ -194,6 +205,8 @@ export async function handler(event, context) {
     const analysis = await analyzeMatch(compactMatch, playerName);
     analysisTimer.end();
 
+    // Open-ended: components is set below, for admins only.
+    /** @type {Record<string, any>} */
     const analysisPayload = {
       flags: 64,
       content: "",
@@ -234,7 +247,8 @@ export async function handler(event, context) {
     const cacheSetTimer = createTimer("cache set");
     await cache.set(cacheNamespace, cacheKey, JSON.stringify(analysisPayload));
     cacheSetTimer.end();
-  } catch (err) {
+  } catch (rawErr) {
+    const err = /** @type {Error} */ (rawErr);
     console.error("DeadlockAnalyst error:", err);
 
     let errorMessage =
@@ -255,6 +269,11 @@ export async function handler(event, context) {
   }
 }
 
+/**
+ * @param {any} compactMatch the compacted match this module builds
+ * @param {string|null} playerName null when the player has no stored name,
+ *   which the prompt and the embed title both phrase around
+ */
 async function analyzeMatch(compactMatch, playerName) {
   const prompt = generateAnalysisPrompt(compactMatch, playerName);
 

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -145,6 +145,9 @@ async function handleMatch(match, user) {
   }
 
   const result = match.match_result === match.player_team ? "won" : "lost";
+  // A hero added since this table was last updated is absent. Announce the match
+  // without a name or portrait rather than throw: handler() does not catch, so a
+  // throw here strands the watermark on this match and every later poll repeats it.
   const hero = constants.heroes[match.hero_id];
 
   const played = withArticle(
@@ -153,7 +156,7 @@ async function handleMatch(match, user) {
     constants.gameModes[metadata?.match_info?.game_mode],
     "match",
   );
-  const description = `${user.name} ${result} ${played} as ${hero.name}`;
+  const description = `${user.name} ${result} ${played} as ${hero?.name || "an unknown hero"}`;
   const fields = [];
 
   fields.push({
@@ -193,7 +196,7 @@ async function handleMatch(match, user) {
   }
 
   let thumbnail = undefined;
-  if (hero.image) {
+  if (hero?.image) {
     thumbnail = {
       url: hero.image,
     };

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -33,10 +33,11 @@ const scanParams = {
   },
 };
 
+/** @returns {Promise<TrackedPlayer[]>} */
 async function loadDBUsers() {
   try {
     const data = await docClient.send(new ScanCommand(scanParams));
-    return data.Items ?? [];
+    return /** @type {TrackedPlayer[]} */ (data.Items ?? []);
   } catch (ex) {
     console.error(`DynamoDB.get error: ${ex}`);
   }
@@ -90,8 +91,36 @@ function formatDuration(duration) {
 }
 
 /**
- * @param {any} match one entry of the match-history response
- * @param {any} user the DynamoDB record for the tracked player
+ * A row of the matches table, which is this repo's own schema.
+ *
+ * @typedef {object} TrackedPlayer
+ * @property {number} player_id
+ * @property {string} name
+ * @property {string} avatar
+ * @property {number} last_match_id
+ */
+
+/**
+ * The fields this handler reads off one match-history entry. Asserted, not
+ * validated: the API returns more, and nothing checks these are present.
+ *
+ * @typedef {object} MatchHistoryEntry
+ * @property {number} match_id
+ * @property {number} match_result
+ * @property {number} player_team
+ * @property {number} hero_id
+ * @property {number} match_duration_s
+ * @property {number} net_worth
+ * @property {number} last_hits
+ * @property {number} denies
+ * @property {number} player_kills
+ * @property {number} player_deaths
+ * @property {number} player_assists
+ */
+
+/**
+ * @param {MatchHistoryEntry} match one entry of the match-history response
+ * @param {TrackedPlayer} user
  * @returns {Promise<{error?: boolean, skipped?: boolean}>} `skipped` still
  *   advances the watermark -- only `error` stops the run and leaves the match
  *   to be retried

--- a/handlers/DeadlockMatches.mjs
+++ b/handlers/DeadlockMatches.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -34,7 +36,7 @@ const scanParams = {
 async function loadDBUsers() {
   try {
     const data = await docClient.send(new ScanCommand(scanParams));
-    return data.Items;
+    return data.Items ?? [];
   } catch (ex) {
     console.error(`DynamoDB.get error: ${ex}`);
   }
@@ -42,6 +44,10 @@ async function loadDBUsers() {
   return [];
 }
 
+/**
+ * @param {number} playerID
+ * @param {number} lastMatchID
+ */
 async function updateDB(playerID, lastMatchID) {
   const params = {
     TableName: tables.matches,
@@ -64,10 +70,12 @@ async function updateDB(playerID, lastMatchID) {
   }
 }
 
+/** @param {number} number */
 function formatNumber(number) {
   return number >= 1000 ? (number / 1000).toFixed(1) + "k" : number;
 }
 
+/** @param {number} duration seconds */
 function formatDuration(duration) {
   const hours = Math.floor(duration / 3600);
   const minutes = Math.floor((duration % 3600) / 60);
@@ -81,6 +89,13 @@ function formatDuration(duration) {
   return parts.join(" ");
 }
 
+/**
+ * @param {any} match one entry of the match-history response
+ * @param {any} user the DynamoDB record for the tracked player
+ * @returns {Promise<{error?: boolean, skipped?: boolean}>} `skipped` still
+ *   advances the watermark -- only `error` stops the run and leaves the match
+ *   to be retried
+ */
 async function handleMatch(match, user) {
   console.log(`Found match: ${match.match_id}`);
 
@@ -90,7 +105,7 @@ async function handleMatch(match, user) {
   // Skip matches with fewer than 2 real players (solo bot matches)
   if (metadata?.match_info?.players) {
     const realPlayerCount = metadata.match_info.players.filter(
-      (p) => p.account_id > 0,
+      (/** @type {any} */ p) => p.account_id > 0,
     ).length;
     if (realPlayerCount < 2) {
       console.log(

--- a/handlers/DiscordWebhookHandler.mjs
+++ b/handlers/DiscordWebhookHandler.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
@@ -7,9 +9,16 @@ const lambda = new LambdaClient({});
 
 const environment = await secrets();
 
+/** @param {string} hex */
 const hexToBytes = (hex) => Uint8Array.from(Buffer.from(hex, "hex"));
 const publicKey = hexToBytes(environment.discord.publicKey);
 
+/**
+ * @param {object} request
+ * @param {string} request.rawBody the body exactly as sent, since the signature
+ *   covers the bytes and not the parsed object
+ * @param {Record<string, string|undefined>} request.headers
+ */
 export async function verifyDiscordRequest({ rawBody, headers }) {
   const sig = headers["x-signature-ed25519"] || headers["X-Signature-Ed25519"];
   const ts =
@@ -35,6 +44,10 @@ export async function verifyDiscordRequest({ rawBody, headers }) {
   );
 }
 
+/**
+ * @param {any} payload
+ * @param {number} [statusCode]
+ */
 function makeResponse(payload, statusCode = 200) {
   return {
     statusCode,
@@ -43,6 +56,7 @@ function makeResponse(payload, statusCode = 200) {
   };
 }
 
+/** @param {any} event the Function URL request, unmodelled */
 export async function handler(event) {
   console.log({ event });
 

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import Discord from "../lib/Discord.mjs";
@@ -27,6 +29,7 @@ const cacheNamespace = "dota-ai-analyzer";
 
 const environment = await secrets();
 
+/** @param {string} operationName */
 function createTimer(operationName) {
   const start = Date.now();
   console.log(`Starting ${operationName}...`);
@@ -50,6 +53,11 @@ const llm = new LLMClient({
   gemini: environment.gemini.apikey,
 });
 
+/**
+ * @param {string|number} match_id
+ * @param {string|number} player_id
+ * @param {string} interaction_token
+ */
 function createRetryRuleName(match_id, player_id, interaction_token) {
   // Hash the interaction token to keep rule name under 64 chars
   const tokenHash = crypto
@@ -60,6 +68,10 @@ function createRetryRuleName(match_id, player_id, interaction_token) {
   return `retry-${match_id}-${player_id}-${tokenHash}`;
 }
 
+/**
+ * @param {any} event the interaction payload relayed by the webhook handler
+ * @param {any} context
+ */
 export async function handler(event, context) {
   const {
     application_id,
@@ -171,7 +183,7 @@ export async function handler(event, context) {
     compactTimer.end();
 
     const player = fullMatch.players.find(
-      (player) => player.account_id === Number(player_id),
+      (/** @type {any} */ player) => player.account_id === Number(player_id),
     );
     const playerHero = DotaConstants.heroes[player.hero_id].name;
     const playerName = player.personaname;
@@ -196,6 +208,8 @@ export async function handler(event, context) {
     );
     analysisTimer.end();
 
+    // Open-ended: components is set below, for admins only.
+    /** @type {Record<string, any>} */
     const analysisPayload = {
       flags: 64,
       content: "",
@@ -234,7 +248,8 @@ export async function handler(event, context) {
     const cacheSetTimer = createTimer("cache set");
     await cache.set(cacheNamespace, cacheKey, JSON.stringify(analysisPayload));
     cacheSetTimer.end();
-  } catch (err) {
+  } catch (rawErr) {
+    const err = /** @type {Error} */ (rawErr);
     console.error("DotaAnalyst error:", err);
 
     let errorMessage =
@@ -255,6 +270,12 @@ export async function handler(event, context) {
   }
 }
 
+/**
+ * @param {any} match the compacted match this module builds
+ * @param {number} playerId
+ * @param {string} playerName
+ * @param {any} fullMatch the OpenDota match, unmodelled
+ */
 async function analyzeMatch(match, playerId, playerName, fullMatch) {
   const promptTimer = createTimer("prompt generation");
   const prompt = await generateAnalysisPrompt(
@@ -299,6 +320,10 @@ async function analyzeMatch(match, playerId, playerName, fullMatch) {
   return response.output;
 }
 
+/**
+ * @param {any} eventPayload replayed verbatim as the retry's input
+ * @param {any} context
+ */
 async function scheduleRetryAnalysis(eventPayload, context) {
   const { match_id, player_id, interaction_token } = eventPayload;
   const ruleName = createRetryRuleName(match_id, player_id, interaction_token);
@@ -325,12 +350,18 @@ async function scheduleRetryAnalysis(eventPayload, context) {
     console.log(
       `Created EventBridge schedule: ${ruleName} scheduled for ${scheduleTime.toISOString()}`,
     );
-  } catch (error) {
+  } catch (rawErr) {
+    const error = /** @type {Error} */ (rawErr);
     console.error(`Failed to schedule retry analysis: ${error.message}`);
     throw error;
   }
 }
 
+/**
+ * @param {string|number} match_id
+ * @param {string|number} player_id
+ * @param {string} interaction_token
+ */
 async function cleanupEventBridgeRule(match_id, player_id, interaction_token) {
   const ruleName = createRetryRuleName(match_id, player_id, interaction_token);
 
@@ -342,8 +373,9 @@ async function cleanupEventBridgeRule(match_id, player_id, interaction_token) {
     );
 
     console.log(`Cleaned up EventBridge schedule: ${ruleName}`);
-  } catch (error) {
+  } catch (rawErr) {
     // Don't throw error if schedule doesn't exist
+    const error = /** @type {Error} */ (rawErr);
     console.log(`Could not cleanup schedule ${ruleName}: ${error.message}`);
   }
 }

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -29,6 +29,13 @@ const cacheNamespace = "dota-ai-analyzer";
 
 const environment = await secrets();
 
+/**
+ * The three fields this handler reads off a match player. Asserted, not
+ * validated -- but enough for the compiler to hold the absent case.
+ *
+ * @typedef {{account_id: number|null, hero_id: number, personaname: string}} MatchPlayer
+ */
+
 /** @param {string} operationName */
 function createTimer(operationName) {
   const start = Date.now();
@@ -182,10 +189,26 @@ export async function handler(event, context) {
     const match = await generateCompactMatch(fullMatch, Number(player_id));
     compactTimer.end();
 
-    const player = fullMatch.players.find(
-      (/** @type {any} */ player) => player.account_id === Number(player_id),
+    // Typed so the compiler keeps the miss below handled. OpenDota reports
+    // account_id as null for players who have not exposed their match data, so
+    // the player can be absent from their own match -- the poller guards the
+    // same lookup for the same reason.
+    const player = /** @type {MatchPlayer[]} */ (fullMatch.players).find(
+      (p) => p.account_id === Number(player_id),
     );
-    const playerHero = DotaConstants.heroes[player.hero_id].name;
+
+    if (!player) {
+      await discord.sendInteractionResponse(application_id, interaction_token, {
+        flags: 64,
+        content: "Player not found in this match.",
+        allowed_mentions: { parse: [] },
+      });
+      return;
+    }
+
+    // dotaconstants trails Valve by a release or two, so a hero added this
+    // patch is missing rather than merely unnamed.
+    const playerHero = DotaConstants.heroes[player.hero_id]?.name || "Unknown";
     const playerName = player.personaname;
 
     await discord.sendInteractionResponse(

--- a/handlers/DotaAnalyst.mjs
+++ b/handlers/DotaAnalyst.mjs
@@ -350,9 +350,8 @@ async function scheduleRetryAnalysis(eventPayload, context) {
     console.log(
       `Created EventBridge schedule: ${ruleName} scheduled for ${scheduleTime.toISOString()}`,
     );
-  } catch (rawErr) {
-    const error = /** @type {Error} */ (rawErr);
-    console.error(`Failed to schedule retry analysis: ${error.message}`);
+  } catch (error) {
+    console.error(`Failed to schedule retry analysis: ${error}`);
     throw error;
   }
 }
@@ -373,9 +372,8 @@ async function cleanupEventBridgeRule(match_id, player_id, interaction_token) {
     );
 
     console.log(`Cleaned up EventBridge schedule: ${ruleName}`);
-  } catch (rawErr) {
+  } catch (error) {
     // Don't throw error if schedule doesn't exist
-    const error = /** @type {Error} */ (rawErr);
-    console.log(`Could not cleanup schedule ${ruleName}: ${error.message}`);
+    console.log(`Could not cleanup schedule ${ruleName}: ${error}`);
   }
 }

--- a/handlers/NoMansSky.mjs
+++ b/handlers/NoMansSky.mjs
@@ -28,12 +28,18 @@ const NAMED_ENTITIES = {
 
 /** @param {string} text */
 function decodeEntities(text) {
-  return text
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
-    .replace(/&(amp|lt|gt|quot|apos);/g, (_, name) => NAMED_ENTITIES[name]);
+  return (
+    text
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+        String.fromCodePoint(parseInt(hex, 16)),
+      )
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+      // Left as-is if the alternation above ever outruns the table.
+      .replace(
+        /&(amp|lt|gt|quot|apos);/g,
+        (m, name) => NAMED_ENTITIES[name] ?? m,
+      )
+  );
 }
 
 const CDATA = /^<!\[CDATA\[([\s\S]*)\]\]>$/;
@@ -50,9 +56,9 @@ function tagText(item, name) {
   );
   if (!match) return "";
 
-  const raw = match[1].trim();
+  const raw = (match[1] ?? "").trim();
   const unwrapped = raw.match(CDATA);
-  return decodeEntities((unwrapped ? unwrapped[1] : raw).trim());
+  return decodeEntities((unwrapped?.[1] ?? raw).trim());
 }
 
 export async function handler() {

--- a/handlers/NoMansSky.mjs
+++ b/handlers/NoMansSky.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import Discord from "../lib/Discord.mjs";
@@ -15,6 +17,7 @@ const FEED_URL = "https://www.nomanssky.com/feed/";
 // the rest, and has been Hello Games' convention across every release since 2016.
 const VERSIONED = /\d+\.\d+/;
 
+/** @type {Record<string, string>} */
 const NAMED_ENTITIES = {
   amp: "&",
   lt: "<",
@@ -23,6 +26,7 @@ const NAMED_ENTITIES = {
   apos: "'",
 };
 
+/** @param {string} text */
 function decodeEntities(text) {
   return text
     .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
@@ -36,6 +40,10 @@ const CDATA = /^<!\[CDATA\[([\s\S]*)\]\]>$/;
 
 // Scoped to one <item>: <channel> opens with its own <title> and <link>, which an
 // unscoped match would take instead.
+/**
+ * @param {string} item
+ * @param {string} name
+ */
 function tagText(item, name) {
   const match = item.match(
     new RegExp(`<${name}(?:\\s[^>]*)?>([\\s\\S]*?)</${name}>`),

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -22,11 +22,64 @@ const openDotaAPI = new OpenDotaAPI(cache, 10_000);
 const environment = await secrets();
 const discord = new Discord(environment.discord);
 
+/**
+ * The fields this handler reads off OpenDota's responses. Asserted, not
+ * validated: OpenDota returns far more, and nothing checks these are present.
+ * Adding a field here is the price of reading one.
+ *
+ * @typedef {object} DotaMatchPlayer
+ * @property {number|null} account_id null when the player has not exposed
+ *   their match data, which is why the lookup below can miss
+ * @property {string} personaname
+ * @property {number} hero_id
+ * @property {number} player_slot
+ * @property {number} kills
+ * @property {number} deaths
+ * @property {number} assists
+ * @property {number} gold_per_min
+ * @property {number} xp_per_min
+ * @property {number} hero_damage
+ * @property {number} hero_healing
+ * @property {number} tower_damage
+ * @property {number|null} [solo_competitive_rank]
+ * @property {number|null} [rank_tier]
+ */
+
+/**
+ * @typedef {object} DotaMatch
+ * @property {number} match_id
+ * @property {number} duration
+ * @property {number} game_mode
+ * @property {number} lobby_type
+ * @property {boolean} radiant_win
+ * @property {number} [skill]
+ * @property {DotaMatchPlayer[]} players
+ */
+
+/**
+ * A row of the tracked-players table, which is this repo's own schema.
+ *
+ * @typedef {object} TrackedPlayer
+ * @property {number} steamID
+ * @property {number} last_matchID
+ */
+
+/**
+ * A tracked player merged with their OpenDota profile, which is what the
+ * announcement and the watermark update both read.
+ *
+ * @typedef {object} AnnouncedPlayer
+ * @property {string} personaname
+ * @property {{avatar: string}} profile
+ * @property {number[]} matches oldest first
+ */
+
 /** @param {number} number */
 function formatNumber(number) {
   return number >= 1000 ? (number / 1000).toFixed(1) + "k" : number;
 }
 
+/** @returns {Promise<TrackedPlayer[]>} */
 async function loadDBUsers() {
   const scanParams = {
     TableName: process.env.table,
@@ -34,7 +87,7 @@ async function loadDBUsers() {
 
   try {
     const result = await docClient.send(new ScanCommand(scanParams));
-    return result.Items ?? [];
+    return /** @type {TrackedPlayer[]} */ (result.Items ?? []);
   } catch (err) {
     console.error("DynamoDB.get error:");
     console.error(err);
@@ -66,7 +119,7 @@ async function loadConfig() {
   }
 }
 
-/** @param {any[]} dbUsers */
+/** @param {TrackedPlayer[]} dbUsers */
 async function collectNewMatches(dbUsers) {
   console.log(`Checking matches for ${dbUsers.length} users`);
 
@@ -76,7 +129,7 @@ async function collectNewMatches(dbUsers) {
   const matches = {};
 
   await Promise.all(
-    dbUsers.map(async (/** @type {any} */ user) => {
+    dbUsers.map(async (user) => {
       /** @type {any[]} */
       let recentMatches;
       // Only this stage is guarded. Later ones abort the run instead, which is safe:
@@ -166,14 +219,14 @@ function getGameMode(modeID, config) {
 
 /**
  * @param {string} steamID
- * @param {any} user
+ * @param {AnnouncedPlayer} user
  * @param {string|number} matchID
- * @param {any} match the OpenDota match, unmodelled
+ * @param {DotaMatch} match
  * @param {Record<string, any>} config
  */
 function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   const dotaPlayer = match.players.find(
-    (/** @type {any} */ player) => player.account_id == steamID,
+    (player) => player.account_id === Number(steamID),
   );
 
   // OpenDota reports account_id as null for players who have not exposed their match
@@ -188,7 +241,7 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
     return null;
   }
 
-  const skill = DotaConstants.skillIDs[match.skill];
+  const skill = DotaConstants.skillIDs[match.skill ?? 0];
   const lobby = DotaConstants.lobbyTypes[match.lobby_type];
   const gameMode = getGameMode(match.game_mode, config);
   const hero = DotaConstants.heroes[dotaPlayer.hero_id];
@@ -199,15 +252,15 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   const heroHealing = formatNumber(dotaPlayer.hero_healing);
   /** @type {any[]} */
   const MMRs = match.players
-    .map((/** @type {any} */ player) => {
+    .map((player) => {
       return player.solo_competitive_rank;
     })
-    .filter((/** @type {any} */ rank) => {
+    .filter((rank) => {
       return rank;
     });
   /** @type {any[]} */
   const rankTiers = match.players
-    .map((/** @type {any} */ player) => {
+    .map((player) => {
       return player.rank_tier;
     })
     .filter((/** @type {any} */ rank) => {

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
@@ -20,6 +22,7 @@ const openDotaAPI = new OpenDotaAPI(cache, 10_000);
 const environment = await secrets();
 const discord = new Discord(environment.discord);
 
+/** @param {number} number */
 function formatNumber(number) {
   return number >= 1000 ? (number / 1000).toFixed(1) + "k" : number;
 }
@@ -31,7 +34,7 @@ async function loadDBUsers() {
 
   try {
     const result = await docClient.send(new ScanCommand(scanParams));
-    return result.Items;
+    return result.Items ?? [];
   } catch (err) {
     console.error("DynamoDB.get error:");
     console.error(err);
@@ -51,10 +54,10 @@ async function loadConfig() {
 
   try {
     const result = await docClient.send(new ScanCommand(scanParams));
-    return result.Items.reduce((config, item) => {
+    return (result.Items ?? []).reduce((config, item) => {
       config[item.Key] = item.Value;
       return config;
-    }, {});
+    }, /** @type {Record<string, any>} */ ({}));
   } catch (err) {
     console.error("DynamoDB.get error:");
     console.error(err);
@@ -63,14 +66,18 @@ async function loadConfig() {
   }
 }
 
+/** @param {any[]} dbUsers */
 async function collectNewMatches(dbUsers) {
   console.log(`Checking matches for ${dbUsers.length} users`);
 
+  /** @type {Record<string, any>} */
   const users = {};
+  /** @type {Record<string, any>} */
   const matches = {};
 
   await Promise.all(
-    dbUsers.map(async (user) => {
+    dbUsers.map(async (/** @type {any} */ user) => {
+      /** @type {any[]} */
       let recentMatches;
       // Only this stage is guarded. Later ones abort the run instead, which is safe:
       // updateDB never runs, so the next poll picks the same matches back up.
@@ -117,6 +124,7 @@ async function collectNewMatches(dbUsers) {
   return { users, matches };
 }
 
+/** @param {Record<string, any>} users */
 async function loadPlayers(users) {
   await Promise.all(
     Object.keys(users).map(async (steamID) => {
@@ -126,12 +134,16 @@ async function loadPlayers(users) {
   );
 }
 
+/**
+ * @param {Record<string, any>} users
+ * @param {Record<string, any>} matches
+ */
 async function loadMatches(users, matches) {
   await Promise.all(
     Object.keys(matches).map(async (matchID) => {
       const match = await openDotaAPI.getMatch(matchID);
       matches[matchID] = match;
-      match.players.forEach((player) => {
+      match.players.forEach((/** @type {any} */ player) => {
         if (player.account_id in users) {
           users[player.account_id].personaname = player.personaname;
         }
@@ -140,6 +152,10 @@ async function loadMatches(users, matches) {
   );
 }
 
+/**
+ * @param {number} modeID
+ * @param {Record<string, any>} config
+ */
 function getGameMode(modeID, config) {
   if (modeID === 19 && "event_name" in config) {
     return config.event_name;
@@ -148,9 +164,16 @@ function getGameMode(modeID, config) {
   return DotaConstants.gameModes[modeID];
 }
 
+/**
+ * @param {string} steamID
+ * @param {any} user
+ * @param {string|number} matchID
+ * @param {any} match the OpenDota match, unmodelled
+ * @param {Record<string, any>} config
+ */
 function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   const dotaPlayer = match.players.find(
-    (player) => player.account_id == steamID,
+    (/** @type {any} */ player) => player.account_id == steamID,
   );
 
   // OpenDota reports account_id as null for players who have not exposed their match
@@ -174,18 +197,20 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   const heroDamage = formatNumber(dotaPlayer.hero_damage);
   const towerDamage = formatNumber(dotaPlayer.tower_damage);
   const heroHealing = formatNumber(dotaPlayer.hero_healing);
+  /** @type {any[]} */
   const MMRs = match.players
-    .map((player) => {
+    .map((/** @type {any} */ player) => {
       return player.solo_competitive_rank;
     })
-    .filter((rank) => {
+    .filter((/** @type {any} */ rank) => {
       return rank;
     });
+  /** @type {any[]} */
   const rankTiers = match.players
-    .map((player) => {
+    .map((/** @type {any} */ player) => {
       return player.rank_tier;
     })
-    .filter((rank) => {
+    .filter((/** @type {any} */ rank) => {
       return rank;
     });
   const durationHours = Math.floor(match.duration / 3600);
@@ -206,6 +231,8 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
     "match",
   );
   const description = `${user.personaname} ${result} ${played} as ${hero.name}`;
+  // Open-ended: the optional rank fields are pushed onto `fields` below.
+  /** @type {Record<string, any>} */
   const embed = {
     author: {
       name: user.personaname,
@@ -291,13 +318,19 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
 // Resolves each user's newest announced match, which is what their watermark may
 // advance to, and is absent when their first match failed to send. Their matches
 // are already oldest first, so a failure stops that user where Discord did.
+/**
+ * @param {Record<string, any>} users
+ * @param {Record<string, any>} matches
+ * @param {Record<string, any>} config
+ */
 async function sendDiscordMessages(users, matches, config) {
+  /** @type {{steamID: string, matchID: any, message: any}[]} */
   const queue = [];
 
   Object.keys(users).forEach((steamID) => {
     const user = users[steamID];
 
-    user.matches.forEach((matchID) => {
+    user.matches.forEach((/** @type {any} */ matchID) => {
       queue.push({
         steamID,
         matchID,
@@ -312,6 +345,7 @@ async function sendDiscordMessages(users, matches, config) {
     });
   });
 
+  /** @type {Record<string, any>} */
   const announced = {};
   const stalled = new Set();
 
@@ -344,6 +378,10 @@ async function sendDiscordMessages(users, matches, config) {
   return announced;
 }
 
+/**
+ * @param {Record<string, any>} users
+ * @param {Record<string, any>} announced
+ */
 async function updateDB(users, announced) {
   await Promise.all(
     Object.keys(announced).map(async (steamID) => {

--- a/handlers/OpenDotaMatches.mjs
+++ b/handlers/OpenDotaMatches.mjs
@@ -275,7 +275,14 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
   }
   duration += `${durationMinutes}m ${durationSeconds}s`;
 
-  const thumbnail_url = `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`;
+  // dotaconstants trails Valve by a release or two, so a hero added this patch is
+  // absent here. Announce the match without a name or portrait rather than throw:
+  // every embed in the run is built before the first send, so one throw would drop
+  // all of them, and it would throw again on every retry because updateDB never
+  // advances past the match.
+  const thumbnail_url = hero
+    ? `http://cdn.dota2.com/apps/dota2/images/dota_react/heroes/${hero.image}.png`
+    : undefined;
 
   const played = withArticle(
     skill && `${skill} skill`,
@@ -283,7 +290,7 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
     gameMode,
     "match",
   );
-  const description = `${user.personaname} ${result} ${played} as ${hero.name}`;
+  const description = `${user.personaname} ${result} ${played} as ${hero?.name || "an unknown hero"}`;
   // Open-ended: the optional rank fields are pushed onto `fields` below.
   /** @type {Record<string, any>} */
   const embed = {
@@ -310,9 +317,7 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
       },
       { name: "duration", value: duration, inline: true },
     ],
-    thumbnail: {
-      url: thumbnail_url,
-    },
+    ...(thumbnail_url && { thumbnail: { url: thumbnail_url } }),
   };
 
   if (MMRs.length > 1) {
@@ -327,23 +332,31 @@ function createDiscordMessageForMatch(steamID, user, matchID, match, config) {
     });
   }
 
-  if (rankTiers.length > 1) {
-    const totalTierIndex = rankTiers
-      .map((rank) => {
-        return DotaConstants.rankTierValues.indexOf(rank);
-      })
-      .reduce((total, rank) => {
-        return (total += rank);
-      }, 0);
-    const estimatedTierIndex = Math.round(totalTierIndex / rankTiers.length);
+  // Averaging index positions rather than the values, because the tiers are not a
+  // number line. Unrecognised tiers are dropped rather than averaged in as -1,
+  // which would silently drag the result toward Herald -- averageBadge does the
+  // same for Deadlock.
+  const tierIndexes = rankTiers
+    .map((rank) => DotaConstants.rankTierValues.indexOf(rank))
+    .filter((index) => index >= 0);
+
+  if (tierIndexes.length > 1) {
+    const totalTierIndex = tierIndexes.reduce(
+      (total, index) => total + index,
+      0,
+    );
+    const estimatedTierIndex = Math.round(totalTierIndex / tierIndexes.length);
     const estimatedTier = DotaConstants.rankTierValues[estimatedTierIndex];
-    const tier = Math.floor(estimatedTier / 10);
-    const subTier = estimatedTier % 10;
-    embed.fields.push({
-      name: "tier",
-      value: `${DotaConstants.rankTiers[tier]} ${subTier}`,
-      inline: true,
-    });
+    const tierName =
+      estimatedTier && DotaConstants.rankTiers[Math.floor(estimatedTier / 10)];
+
+    if (tierName) {
+      embed.fields.push({
+        name: "tier",
+        value: `${tierName} ${estimatedTier % 10}`,
+        inline: true,
+      });
+    }
   }
 
   embed.fields.push({

--- a/handlers/SteamUpdates.mjs
+++ b/handlers/SteamUpdates.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 "use strict";
 
 import Discord from "../lib/Discord.mjs";
@@ -139,10 +141,12 @@ const games = [
       "https://cdn.cloudflare.steamstatic.com/steam/apps/570/header.jpg",
     eventTypes: DEFAULT_EVENT_TYPES,
     // Valve serves these posts by gid on dota2.com too
-    newsUrl: (gid) => `https://www.dota2.com/newsentry/${gid}`,
+    newsUrl: (/** @type {string} */ gid) =>
+      `https://www.dota2.com/newsentry/${gid}`,
   },
 ];
 
+/** @param {(typeof games)[number]} game */
 async function processGame(game) {
   try {
     const db = await loadFeedData(game.key);
@@ -150,10 +154,10 @@ async function processGame(game) {
       "https://store.steampowered.com/events/ajaxgetpartnereventspageable/",
       {
         qs: {
-          clan_accountid: 0,
-          appid: game.appid,
-          offset: 0,
-          count: 10,
+          clan_accountid: "0",
+          appid: String(game.appid),
+          offset: "0",
+          count: "10",
           l: "english",
         },
         headers: {
@@ -172,7 +176,8 @@ async function processGame(game) {
     let data;
     try {
       data = JSON.parse(raw_data);
-    } catch (parseError) {
+    } catch (rawErr) {
+      const parseError = /** @type {Error} */ (rawErr);
       console.error(
         `Failed to parse JSON response for ${game.name}:`,
         parseError.message,
@@ -191,7 +196,9 @@ async function processGame(game) {
     for (const eventType of game.eventTypes) {
       // Steam returns events newest-first, so the stored gid acts as a
       // watermark: everything above it in the list is still unposted.
-      const typeEvents = (data.events ?? []).filter(
+      /** @type {any[]} */
+      const events = data.events ?? [];
+      const typeEvents = events.filter(
         (event) => event.event_type === eventType.id,
       );
 
@@ -248,7 +255,8 @@ async function processGame(game) {
     if (hasNewEvents) {
       await updateFeedData(game.key, updatedTracking);
     }
-  } catch (error) {
+  } catch (rawErr) {
+    const error = /** @type {Error} */ (rawErr);
     console.error(`Error processing ${game.name}:`, error.message);
   }
 }

--- a/handlers/SteamUpdates.mjs
+++ b/handlers/SteamUpdates.mjs
@@ -176,11 +176,9 @@ async function processGame(game) {
     let data;
     try {
       data = JSON.parse(raw_data);
-    } catch (rawErr) {
-      const parseError = /** @type {Error} */ (rawErr);
+    } catch (parseError) {
       console.error(
-        `Failed to parse JSON response for ${game.name}:`,
-        parseError.message,
+        `Failed to parse JSON response for ${game.name}: ${parseError}`,
       );
       console.error("Response preview:", raw_data.substring(0, 200));
       return;
@@ -255,9 +253,8 @@ async function processGame(game) {
     if (hasNewEvents) {
       await updateFeedData(game.key, updatedTracking);
     }
-  } catch (rawErr) {
-    const error = /** @type {Error} */ (rawErr);
-    console.error(`Error processing ${game.name}:`, error.message);
+  } catch (error) {
+    console.error(`Error processing ${game.name}: ${error}`);
   }
 }
 

--- a/lib/DeadlockAPI.mjs
+++ b/lib/DeadlockAPI.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { averageBadge } from "./DeadlockConstants.mjs";
 
 const SEVEN_DAYS = 7 * 24 * 60 * 60;
@@ -17,7 +19,7 @@ class DeadlockAPI {
   #cache;
 
   /**
-   * @param {Object|null} cache - Cache implementation with get/set methods, or null to disable caching
+   * @param {import("./cache.mjs").CacheLike|null} [cache] null to disable caching
    */
   constructor(cache = null) {
     this.#cache = cache;
@@ -25,7 +27,8 @@ class DeadlockAPI {
 
   /**
    * Fetch match metadata from Deadlock API
-   * @private
+   * @param {string|number} matchId
+   * @returns {Promise<any>} the API's body, which this module does not model
    */
   async #fetchMatchMetadataFromAPI(matchId) {
     const controller = new AbortController();
@@ -55,9 +58,9 @@ class DeadlockAPI {
   /**
    * Get match metadata by match ID with optional caching
    * @param {string|number} matchId - Match ID
-   * @param {Object} options - Options
-   * @param {boolean} options.skipCache - Skip cache lookup and storage
-   * @returns {Promise<Object|null>} Match metadata or null if not found
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.skipCache] - Skip cache lookup and storage
+   * @returns {Promise<any|null>} Match metadata or null if not found
    */
   async getMatchMetadata(matchId, { skipCache = false } = {}) {
     const cacheKey = `metadata:${matchId}`;
@@ -96,7 +99,10 @@ class DeadlockAPI {
 
   /**
    * Fetch popular items from Deadlock API analytics endpoint
-   * @private
+   * @param {number} heroId
+   * @param {number} minBadge
+   * @param {number} minMatches
+   * @returns {Promise<any>} the API's body, which this module does not model
    */
   async #fetchPopularItemsFromAPI(heroId, minBadge, minMatches) {
     const controller = new AbortController();
@@ -129,10 +135,10 @@ class DeadlockAPI {
    * Get popular items for a hero at a skill level with optional caching
    * @param {number} heroId - Hero ID
    * @param {number} minBadge - Minimum average badge (rank) to filter by
-   * @param {Object} options - Options
-   * @param {boolean} options.skipCache - Skip cache lookup and storage
-   * @param {number} options.minMatches - Minimum number of matches required (default: 100)
-   * @returns {Promise<Array|null>} Array of popular items sorted by win rate, or null if not found
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.skipCache] - Skip cache lookup and storage
+   * @param {number} [options.minMatches] - Minimum number of matches required (default: 100)
+   * @returns {Promise<any[]|null>} Array of popular items sorted by win rate, or null if not found
    */
   async getPopularItems(
     heroId,
@@ -206,7 +212,9 @@ class DeadlockAPI {
    * `players/mmr` is deprecated in favour of the single-player `players/{id}/rank`,
    * but it is the only batched form, and a rank field is not worth twelve requests.
    *
-   * @private
+   * @param {number[]} accountIds
+   * @returns {Promise<number[]>} empty on any failure, so a caller sees no ranks
+   *   rather than a throw
    */
   async #playerBadges(accountIds) {
     const ids = accountIds.filter((id) => id > 0).sort((a, b) => a - b);
@@ -242,7 +250,7 @@ class DeadlockAPI {
         return [];
       }
 
-      const badges = (await res.json())
+      const badges = /** @type {any[]} */ (await res.json())
         .map((player) => player.rank)
         .filter(Boolean);
 
@@ -268,10 +276,11 @@ class DeadlockAPI {
   }
 
   /**
-   * @param {Object} matchInfo - `match_info` from match metadata
+   * @param {any} matchInfo - `match_info` from match metadata, unmodelled
    * @returns {Promise<number|null>} Badge as `tier * 10 + subrank`
    */
   async getMatchAverageBadge(matchInfo) {
+    /** @type {any[]|undefined} */
     const players = matchInfo?.players;
     if (!players?.length) return null;
 

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -1,7 +1,8 @@
 // @ts-check
 
-// Indexed by hero_id straight off the API, so a hero Valve added since the last
-// update reads as undefined rather than failing to compile.
+// Indexed by hero_id straight off the API, so a hero added since this table was
+// last updated is missing. Typed as possibly-undefined to force every caller to
+// say what it does about that.
 /** @type {Record<number, {name: string, image: string}>} */
 export const heroes = {
   1: {
@@ -253,7 +254,7 @@ export function averageBadge(badges) {
   if (indexes.length < 2) return null;
 
   const mean = indexes.reduce((sum, index) => sum + index, 0) / indexes.length;
-  return badgeValues[Math.round(mean)];
+  return badgeValues[Math.round(mean)] ?? null;
 }
 
 /** @type {Record<number, string>} */

--- a/lib/DeadlockConstants.mjs
+++ b/lib/DeadlockConstants.mjs
@@ -1,3 +1,8 @@
+// @ts-check
+
+// Indexed by hero_id straight off the API, so a hero Valve added since the last
+// update reads as undefined rather than failing to compile.
+/** @type {Record<number, {name: string, image: string}>} */
 export const heroes = {
   1: {
     name: "Infernus",
@@ -243,7 +248,7 @@ const badgeValues = ranks.flatMap((_, tier) =>
  */
 export function averageBadge(badges) {
   const indexes = badges
-    .map((badge) => badgeValues.indexOf(badge))
+    .map((badge) => (badge == null ? -1 : badgeValues.indexOf(badge)))
     .filter((index) => index >= 0);
   if (indexes.length < 2) return null;
 
@@ -251,12 +256,14 @@ export function averageBadge(badges) {
   return badgeValues[Math.round(mean)];
 }
 
+/** @type {Record<number, string>} */
 export const matchModes = {
   1: "unranked",
   4: "ranked",
 };
 
 // Only the modes worth naming; normal reads as a plain "match".
+/** @type {Record<number, string>} */
 export const gameModes = {
   4: "street brawl",
 };
@@ -269,6 +276,8 @@ export const gameModes = {
  * @returns {string|null} e.g. "Ritualist 1", or null when there is no rank
  */
 export function formatBadge(badge) {
+  if (badge == null) return null;
+
   const tier = Math.floor(badge / 10);
   if (!tier || !ranks[tier]) return null;
 

--- a/lib/DeadlockMatchProcessor.mjs
+++ b/lib/DeadlockMatchProcessor.mjs
@@ -768,6 +768,13 @@ export function detectTeamfights(matchData) {
   return teamfights;
 }
 
+/**
+ * @param {any} matchData `match_info` from the match metadata
+ * @param {number} focusPlayerId
+ * @param {any} itemsData
+ * @param {any[]|null} [popularItemsData]
+ * @param {number|null} [averageBadge]
+ */
 export function generateCompactMatch(
   matchData,
   focusPlayerId,
@@ -1372,7 +1379,7 @@ SCHEMA
 /**
  * Generate analysis prompt for Deadlock match
  * @param {Object} compactMatch - Compact match data from generateCompactMatch
- * @param {string} playerName - Player name
+ * @param {string|null} playerName - Player name, or null if unknown
  * @returns {Array} - Array of prompt messages
  */
 export function generateAnalysisPrompt(compactMatch, playerName) {

--- a/lib/Discord.mjs
+++ b/lib/Discord.mjs
@@ -1,14 +1,28 @@
+// @ts-check
+
 export default class Discord {
   #channels;
   #userAgent;
   #apikey;
 
+  /**
+   * @param {object} options
+   * @param {Record<string, string>} options.channels name to Discord channel id
+   * @param {string} options.userAgent
+   * @param {string} options.apikey
+   */
   constructor({ channels, userAgent, apikey }) {
     this.#channels = channels;
     this.#userAgent = userAgent;
     this.#apikey = apikey;
   }
 
+  /**
+   * @param {Record<string, any>} embed a Discord embed, built by the caller
+   * @param {string} [channel] a key of `channels`, defaulting to "default"
+   * @param {any[]} [components]
+   * @returns {Promise<{error: boolean}>}
+   */
   async sendEmbed(embed, channel, components) {
     if (!channel) {
       channel = "default";
@@ -19,6 +33,8 @@ export default class Discord {
       throw new Error(`Unknown channel: ${channel}`);
     }
 
+    // Open-ended: components is set after construction.
+    /** @type {Record<string, any>} */
     const payload = {
       embeds: [embed],
       allow_mentions: { parse: [] },
@@ -48,7 +64,7 @@ export default class Discord {
       err = fetchError;
     }
 
-    const hadError = !!err || response.status !== 200;
+    const hadError = !!err || response?.status !== 200;
     if (hadError) {
       console.error("Error sending discord message:");
       console.error({
@@ -62,6 +78,12 @@ export default class Discord {
     return { error: hadError };
   }
 
+  /**
+   * @param {string} applicationID
+   * @param {string} interactionToken
+   * @param {Record<string, any>} payload
+   * @param {boolean} [update] PATCH the deferred reply rather than POST a new one
+   */
   async sendInteractionResponse(
     applicationID,
     interactionToken,

--- a/lib/Discord.mjs
+++ b/lib/Discord.mjs
@@ -33,15 +33,11 @@ export default class Discord {
       throw new Error(`Unknown channel: ${channel}`);
     }
 
-    // Open-ended: components is set after construction.
-    /** @type {Record<string, any>} */
     const payload = {
       embeds: [embed],
       allow_mentions: { parse: [] },
+      ...(components && { components }),
     };
-    if (components) {
-      payload.components = components;
-    }
 
     let response;
     let body;

--- a/lib/DotaConstants.mjs
+++ b/lib/DotaConstants.mjs
@@ -9,6 +9,8 @@ import {
 // Transform heroes from dotaconstants format to our API
 // Package: { "1": { id: 1, localized_name: "Anti-Mage", name: "npc_dota_hero_antimage", icon: "..." } }
 // Our API: { 1: { name: "Anti-Mage", image: "antimage", raw_name: "npc_dota_hero_antimage" } }
+// dotaconstants trails Valve by a release or two, so a hero added this patch is
+// absent. Typed as possibly-undefined to force every caller to say so.
 /** @type {Record<string, {name: string, image: string, raw_name: string}>} */
 const heroes = {};
 for (const [id, hero] of Object.entries(heroesData)) {

--- a/lib/DotaConstants.mjs
+++ b/lib/DotaConstants.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Import from dotaconstants package for heroes and game modes
 import {
   heroes as heroesData,
@@ -7,11 +9,12 @@ import {
 // Transform heroes from dotaconstants format to our API
 // Package: { "1": { id: 1, localized_name: "Anti-Mage", name: "npc_dota_hero_antimage", icon: "..." } }
 // Our API: { 1: { name: "Anti-Mage", image: "antimage", raw_name: "npc_dota_hero_antimage" } }
+/** @type {Record<string, {name: string, image: string, raw_name: string}>} */
 const heroes = {};
 for (const [id, hero] of Object.entries(heroesData)) {
   // Extract image name from icon path: "/apps/dota2/images/dota_react/heroes/icons/antimage.png?"
   const imageName = hero.icon
-    ? hero.icon.split("/").pop().replace(".png?", "")
+    ? hero.icon.replace(/^.*\//, "").replace(".png?", "")
     : hero.name.replace("npc_dota_hero_", "");
 
   heroes[id] = {
@@ -24,6 +27,7 @@ for (const [id, hero] of Object.entries(heroesData)) {
 // Transform game modes from dotaconstants format to our API
 // Package: { "18": { id: 18, name: "game_mode_ability_draft" } }
 // Our API: { 18: "Ability Draft" }
+/** @type {Record<string, string>} */
 const gameModes = {};
 for (const [id, mode] of Object.entries(gameModesData)) {
   // Transform "game_mode_ability_draft" to "Ability Draft"
@@ -50,6 +54,7 @@ gameModes["21"] = "1v1 Solo Mid";
 gameModes["22"] = "All Pick";
 
 // Lobby types - custom definitions (package names are too generic)
+/** @type {Record<number, string>} */
 const lobbyTypes = {
   "-1": "Invalid",
   0: "Unranked",
@@ -64,6 +69,7 @@ const lobbyTypes = {
 };
 
 // Custom constants not available in dotaconstants package
+/** @type {Record<number, string>} */
 const skillIDs = {
   0: "",
   1: "Normal",
@@ -71,6 +77,7 @@ const skillIDs = {
   3: "Very High",
 };
 
+/** @type {Record<number, string>} */
 const rankTiers = {
   0: "Uncalibrated",
   1: "Herald",

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -1,5 +1,32 @@
+// @ts-check
+
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;
+
+/**
+ * The flags are absent on anything that is not a provider HTTP failure -- a
+ * bug in this file, or an aborted request -- and both reads treat that as
+ * "do not retry, do not step down".
+ *
+ * @typedef {Error & {status?: number, retryable?: boolean, tryNextModel?: boolean}} ProviderError
+ */
+
+/**
+ * A chat message as the callers build them, not as any provider returns them.
+ * @typedef {{role: string, content: string}} Message
+ */
+
+/**
+ * Normalised across the three providers, so prompt + completion + reasoning is
+ * the total on all of them. None of them reports it that way natively.
+ *
+ * @typedef {object} Usage
+ * @property {number} prompt_tokens
+ * @property {number} completion_tokens
+ * @property {number} cached_tokens
+ * @property {number} reasoning_tokens
+ * @property {number} total_tokens
+ */
 
 /**
  * Classifies a provider's HTTP failure along two independent axes.
@@ -11,8 +38,14 @@ const RETRY_DELAY_MS = 300;
  * `tryNextModel` -- worth asking a different model. Rate limits qualify because
  * the caps are per model, and so does a 404: providers retire models, and a
  * stale name in a fallback chain must not take down the models below it.
+ *
+ * @param {string} provider
+ * @param {number} status
+ * @param {string} text
+ * @returns {ProviderError}
  */
 function providerError(provider, status, text) {
+  /** @type {ProviderError} */
   const err = new Error(`${provider} error ${status}: ${text}`);
   err.status = status;
   err.retryable = status >= 500;
@@ -37,7 +70,7 @@ export default class LLMClient {
 
   /**
    * Call a model from any provider (auto-detects provider from model name)
-   * @param {Array} messages - Array of {role, content} messages
+   * @param {Message[]} messages
    * @param {string} model - Model name (e.g., 'gpt-5', 'claude-sonnet-4-5', 'gemini-2.5-flash')
    * @param {object} [schema] - JSON Schema to constrain the output. All three
    *   providers accept the same standard schema; only where it goes in the
@@ -45,7 +78,8 @@ export default class LLMClient {
    *   every property in `required`, which OpenAI's strict mode demands and the
    *   other two tolerate. Without a schema the model is asked for JSON but not
    *   held to it, and some emit a duplicated closing brace or a code fence.
-   * @returns {Promise<{output: object, usage: object, response_time_ms: number}>}
+   * @returns {Promise<{output: any, usage: Usage, response_time_ms: number}>}
+   *   `output` is the model's JSON: schema-constrained, but never verified here
    */
   async call(messages, model, schema) {
     const startTime = Date.now();
@@ -80,10 +114,10 @@ export default class LLMClient {
    * prompt does not step down: it fails identically on every model, so walking
    * the chain would return the same error more slowly.
    *
-   * @param {Array} messages - Array of {role, content} messages
+   * @param {Message[]} messages
    * @param {string[]} models - Models to try, best first
    * @param {object} [schema] - JSON Schema to constrain the output
-   * @returns {Promise<{output: object, usage: object, response_time_ms: number, model: string}>}
+   * @returns {Promise<{output: any, usage: Usage, response_time_ms: number, model: string}>}
    *   `model` is the one that actually answered, which is not always models[0]
    */
   async callWithFallback(messages, models, schema) {
@@ -97,7 +131,8 @@ export default class LLMClient {
       try {
         const result = await this.call(messages, model, schema);
         return { ...result, model };
-      } catch (err) {
+      } catch (rawErr) {
+        const err = /** @type {ProviderError} */ (rawErr);
         if (!err.tryNextModel) throw err;
         lastErr = err;
         console.warn(
@@ -125,9 +160,9 @@ export default class LLMClient {
   /**
    * Call OpenAI API
    * @param {string} model - Model name (e.g., 'gpt-5')
-   * @param {Array} messages - Array of {role, content} messages
+   * @param {Message[]} messages
    * @param {object} [schema] - JSON Schema to constrain the output
-   * @returns {Promise<{output: object, usage: object}>}
+   * @returns {Promise<{output: any, usage: Usage}>}
    */
   async #callOpenAI(model, messages, schema) {
     const body = {
@@ -160,7 +195,9 @@ export default class LLMClient {
           throw providerError("OpenAI", res.status, text);
         }
 
-        const data = await res.json();
+        // Provider response bodies are not modelled: each one is a distinct
+        // shape that only this method reads, and only to build `usage`.
+        const data = /** @type {any} */ (await res.json());
 
         const rawContent = data.choices[0].message.content;
 
@@ -181,7 +218,8 @@ export default class LLMClient {
             reasoning_tokens: reasoningTokens,
           },
         };
-      } catch (err) {
+      } catch (rawErr) {
+        const err = /** @type {ProviderError} */ (rawErr);
         console.error(`OpenAI attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
         if (err.status && !err.retryable) break;
@@ -199,15 +237,17 @@ export default class LLMClient {
   /**
    * Call Anthropic Claude API
    * @param {string} model - Model name (e.g., 'claude-sonnet-4-5')
-   * @param {Array} messages - Array of {role, content} messages
+   * @param {Message[]} messages
    * @param {object} [schema] - JSON Schema to constrain the output
-   * @returns {Promise<{output: object, usage: object}>}
+   * @returns {Promise<{output: any, usage: Usage}>}
    */
   async #callAnthropic(model, messages, schema) {
     // Extract system message from messages array
     const systemMessage = messages.find((m) => m.role === "system");
     const userMessages = messages.filter((m) => m.role !== "system");
 
+    // Open-ended: the two conditional fields below are set after construction.
+    /** @type {Record<string, any>} */
     const body = {
       model,
       max_tokens: 4096,
@@ -242,7 +282,9 @@ export default class LLMClient {
           throw providerError("Anthropic", res.status, text);
         }
 
-        const data = await res.json();
+        // Provider response bodies are not modelled: each one is a distinct
+        // shape that only this method reads, and only to build `usage`.
+        const data = /** @type {any} */ (await res.json());
 
         // Claude returns text content, need to parse JSON
         let contentText = data.content[0].text;
@@ -268,7 +310,8 @@ export default class LLMClient {
               (data.usage.cache_creation_input_tokens || 0),
           },
         };
-      } catch (err) {
+      } catch (rawErr) {
+        const err = /** @type {ProviderError} */ (rawErr);
         console.error(`Anthropic attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
         if (err.status && !err.retryable) break;
@@ -286,9 +329,9 @@ export default class LLMClient {
   /**
    * Call Google Gemini API
    * @param {string} model - Model name (e.g., 'gemini-2.5-flash')
-   * @param {Array} messages - Array of {role, content} messages
+   * @param {Message[]} messages
    * @param {object} [schema] - JSON Schema to constrain the output
-   * @returns {Promise<{output: object, usage: object}>}
+   * @returns {Promise<{output: any, usage: Usage}>}
    */
   async #callGemini(model, messages, schema) {
     // Gemini has a different message format
@@ -304,6 +347,8 @@ export default class LLMClient {
       parts: [{ text: msg.content }],
     }));
 
+    // Open-ended: system_instruction is set after construction.
+    /** @type {Record<string, any>} */
     const body = {
       contents,
       generationConfig: {
@@ -340,7 +385,9 @@ export default class LLMClient {
           throw providerError("Gemini", res.status, text);
         }
 
-        const data = await res.json();
+        // Provider response bodies are not modelled: each one is a distinct
+        // shape that only this method reads, and only to build `usage`.
+        const data = /** @type {any} */ (await res.json());
 
         // Parse the JSON response from Gemini
         let contentText = data.candidates[0].content.parts[0].text;
@@ -366,7 +413,8 @@ export default class LLMClient {
             total_tokens: usage.totalTokenCount || 0,
           },
         };
-      } catch (err) {
+      } catch (rawErr) {
+        const err = /** @type {ProviderError} */ (rawErr);
         console.error(`Gemini attempt ${attempt + 1} failed:`, err.message);
         lastErr = err;
         if (err.status && !err.retryable) break;

--- a/lib/LLMClient.mjs
+++ b/lib/LLMClient.mjs
@@ -246,21 +246,15 @@ export default class LLMClient {
     const systemMessage = messages.find((m) => m.role === "system");
     const userMessages = messages.filter((m) => m.role !== "system");
 
-    // Open-ended: the two conditional fields below are set after construction.
-    /** @type {Record<string, any>} */
     const body = {
       model,
       max_tokens: 4096,
       messages: userMessages,
+      ...(systemMessage && { system: systemMessage.content }),
+      ...(schema && {
+        output_config: { format: { type: "json_schema", schema } },
+      }),
     };
-
-    if (systemMessage) {
-      body.system = systemMessage.content;
-    }
-
-    if (schema) {
-      body.output_config = { format: { type: "json_schema", schema } };
-    }
 
     let attempt = 0;
     let lastErr;
@@ -347,8 +341,6 @@ export default class LLMClient {
       parts: [{ text: msg.content }],
     }));
 
-    // Open-ended: system_instruction is set after construction.
-    /** @type {Record<string, any>} */
     const body = {
       contents,
       generationConfig: {
@@ -357,13 +349,10 @@ export default class LLMClient {
         // additionalProperties, which OpenAI's strict mode requires.
         ...(schema && { response_json_schema: schema }),
       },
+      ...(systemMessage && {
+        system_instruction: { parts: [{ text: systemMessage.content }] },
+      }),
     };
-
-    if (systemMessage) {
-      body.system_instruction = {
-        parts: [{ text: systemMessage.content }],
-      };
-    }
 
     let attempt = 0;
     let lastErr;

--- a/lib/OpenDotaAPI.mjs
+++ b/lib/OpenDotaAPI.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 const SEVEN_DAYS = 7 * 24 * 60 * 60;
 const API_PREFIX = "https://api.opendota.com/api/";
 const CACHE_NAMESPACE = "opendota-matches";
@@ -8,11 +10,20 @@ export default class OpenDotaAPI {
 
   // Timeout is per caller, not shared: the poller has 30s for a whole run, the analyst
   // 180s for one multi-megabyte parsed match.
+  /**
+   * @param {import("./cache.mjs").CacheLike | null} [cache]
+   * @param {number} [timeout] milliseconds
+   */
   constructor(cache = null, timeout = undefined) {
     this.#cache = cache;
     this.#timeout = timeout;
   }
 
+  /**
+   * @param {string} path
+   * @param {Record<string, string>} [params]
+   * @returns {Promise<any>} OpenDota's body, which this module does not model
+   */
   async #getRequest(path, params) {
     const query = params ? `?${new URLSearchParams(params)}` : "";
 
@@ -27,6 +38,7 @@ export default class OpenDotaAPI {
     return response.json();
   }
 
+  /** @param {number|string} matchID */
   async getMatch(matchID) {
     const cacheKey = `match:${matchID}`;
 
@@ -55,21 +67,25 @@ export default class OpenDotaAPI {
     return match;
   }
 
+  /** @param {number|string} steamID */
   async getRecentMatches(steamID) {
     return this.#getRequest(`players/${steamID}/matches`, {
-      limit: 10,
-      significant: 0,
+      limit: "10",
+      significant: "0",
     });
   }
 
+  /** @param {number|string} steamID */
   async getPlayer(steamID) {
     return this.#getRequest(`players/${steamID}`);
   }
 
+  /** @param {number|string} heroID */
   async getHeroItemPopularity(heroID) {
     return this.#getRequest(`heroes/${heroID}/itemPopularity`);
   }
 
+  /** @param {number|string} matchID */
   async requestParse(matchID) {
     const response = await fetch(`${API_PREFIX}request/${matchID}`, {
       method: "POST",

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -61,14 +61,11 @@ export const ANALYSIS_MODELS = [
  * @param {Analysis} analysis
  */
 export function analysisFields(analysis) {
-  /** @type {[string, string[] | undefined][]} */
-  const sections = [
+  return /** @type {[string, string[] | undefined][]} */ ([
     ["Highlights", analysis.strengths],
     ["Focus areas", analysis.weaknesses],
     ["Recommendations", analysis.recommendations],
-  ];
-
-  return sections.flatMap(([name, items]) =>
+  ]).flatMap(([name, items]) =>
     items?.length
       ? [{ name, value: items.map((txt) => `- ${txt}`).join("\n") }]
       : [],

--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * What the two analysts ask the model for, and how the answer is rendered.
  */
@@ -41,18 +43,34 @@ export const ANALYSIS_MODELS = [
 ];
 
 /**
+ * The model's answer, shaped by ANALYSIS_SCHEMA. The lists are optional here
+ * even though the schema requires them, because a model that ignores the
+ * schema is the case this module exists to survive.
+ *
+ * @typedef {object} Analysis
+ * @property {string} summary
+ * @property {string[]} [strengths]
+ * @property {string[]} [weaknesses]
+ * @property {string[]} [recommendations]
+ */
+
+/**
  * Discord rejects an embed field with an empty value, which would lose the
  * whole analysis over one section the model left empty.
+ *
+ * @param {Analysis} analysis
  */
 export function analysisFields(analysis) {
-  return [
+  /** @type {[string, string[] | undefined][]} */
+  const sections = [
     ["Highlights", analysis.strengths],
     ["Focus areas", analysis.weaknesses],
     ["Recommendations", analysis.recommendations],
-  ]
-    .filter(([, items]) => items?.length)
-    .map(([name, items]) => ({
-      name,
-      value: items.map((txt) => `- ${txt}`).join("\n"),
-    }));
+  ];
+
+  return sections.flatMap(([name, items]) =>
+    items?.length
+      ? [{ name, value: items.map((txt) => `- ${txt}`).join("\n") }]
+      : [],
+  );
 }

--- a/lib/cache.mjs
+++ b/lib/cache.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
@@ -20,9 +22,18 @@ const DEFAULT_TTL = 7 * 24 * 60 * 60;
 const nowSec = () => Math.floor(Date.now() / 1000);
 
 /**
+ * What the API clients depend on, rather than this module itself, so a caller
+ * can hand them a stand-in that does not reach DynamoDB.
+ *
+ * @typedef {object} CacheLike
+ * @property {(namespace: string, key: string) => Promise<string|null>} get
+ * @property {(namespace: string, key: string, value: string, ttl?: number) => Promise<void>} set
+ */
+
+/**
  * @param {string} namespace
  * @param {string} key
- * @returns {Promise<string>}
+ * @returns {Promise<string|null>} null when absent or expired
  */
 async function get(namespace, key) {
   const res = await dynamo.send(

--- a/lib/secrets.mjs
+++ b/lib/secrets.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
 
 const client = new SSMClient({});
@@ -12,7 +14,12 @@ async function fetchSecrets() {
     new GetParameterCommand({ Name: name, WithDecryption: true }),
   );
 
-  return JSON.parse(result.Parameter.Value);
+  const value = result.Parameter?.Value;
+  if (!value) {
+    throw new Error(`SSM parameter ${name} is empty`);
+  }
+
+  return JSON.parse(value);
 }
 
 // Not reset on failure: callers await at module scope, so a rejection discards the sandbox.

--- a/lib/tables.mjs
+++ b/lib/tables.mjs
@@ -1,7 +1,10 @@
+// @ts-check
+
 // The CDK stack is the source of truth for table names and injects each one as an
 // environment variable. Handlers read them here rather than hardcoding literals, so a
 // rename is a stack change and never a code edit.
 
+/** @param {string} name */
 function required(name) {
   const value = process.env[name];
   if (!value) {

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
@@ -14,6 +16,14 @@ const USER_AGENT = "c0rbot/1.0 (+https://github.com/coreymaher/c0rbot)";
 
 // Resolves the response body, or `undefined` on any failure -- callers treat a falsy
 // result as a transient error and skip the run.
+/**
+ * @param {string} url
+ * @param {object} [options]
+ * @param {Record<string, string>} [options.qs]
+ * @param {Record<string, string>} [options.headers]
+ * @param {number} [options.timeout]
+ * @returns {Promise<string|undefined>}
+ */
 export async function simpleGet(url, { qs, headers, timeout } = {}) {
   const target = qs ? `${url}?${new URLSearchParams(qs)}` : url;
 
@@ -38,12 +48,18 @@ export async function simpleGet(url, { qs, headers, timeout } = {}) {
 
 // Nothing in either game's mode and lobby tables starts with a sounded "u",
 // which is where picking the article by leading vowel would break ("a user").
+/** @param {...(string|false|null|undefined)} parts */
 export function withArticle(...parts) {
   const phrase = parts.filter(Boolean).join(" ");
 
   return `${/^[aeiou]/i.test(phrase) ? "an" : "a"} ${phrase}`;
 }
 
+/**
+ * @param {string} key
+ * @returns {Promise<{Item?: Record<string, any>}>} `{}` on error, so a caller
+ *   that reads `Item` sees a miss rather than a throw
+ */
 export async function loadFeedData(key) {
   try {
     const params = {
@@ -61,6 +77,10 @@ export async function loadFeedData(key) {
   }
 }
 
+/**
+ * @param {string} key
+ * @param {any} feedData whatever shape the calling handler tracks
+ */
 export async function updateFeedData(key, feedData) {
   try {
     const params = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.28.1",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "typescript": "~7.0.2"
       }
     },
     "cdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotaconstants": "^10.8.0"
       },
       "devDependencies": {
+        "@types/node": "^24.10.1",
         "esbuild": "^0.28.1",
         "prettier": "^3.6.2",
         "typescript": "~7.0.2"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   },
   "devDependencies": {
     "esbuild": "^0.28.1",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "typescript": "~7.0.2"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "decrypt": "sops -d environment.js.enc > environment.js",
     "encrypt": "sops -e environment.js > environment.js.enc",
     "secrets:push": "./scripts/push-secrets.sh",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotaconstants": "^10.8.0"
   },
   "devDependencies": {
+    "@types/node": "^24.10.1",
     "esbuild": "^0.28.1",
     "prettier": "^3.6.2",
     "typescript": "~7.0.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["es2023"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
     "types": ["node"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the Lambda source in place. Nothing here feeds the build: esbuild
+  // bundles the .mjs files directly and never type-checks, so this is a separate
+  // gate run by `npm run typecheck`. cdk/ has its own tsconfig and is not included.
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["es2023"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "allowJs": true,
+    // Off by design: files opt in with `// @ts-check` so the conversion can go one
+    // file at a time. Flipping this to true checks everything at once instead.
+    "checkJs": false,
+    "noEmit": true
+  },
+  "include": ["handlers/**/*.mjs", "lib/**/*.mjs"],
+  "exclude": ["node_modules", "cdk"]
+}


### PR DESCRIPTION
Adds `npm run typecheck` and opts 18 of the 20 source files into it. The source stays
`.mjs` and the types live in JSDoc — no renames, no change to how esbuild bundles, and no
way for this to alter runtime behaviour.

## How it is wired

`tsconfig.json` sets `allowJs` with `checkJs: false`, and a file opts in with `// @ts-check`
on its first line. Adoption goes one file at a time, and a file that has not opted in
reports nothing.

`noUncheckedIndexedAccess` is on alongside `strict`, and is the setting that pays for
itself — see the last commit.

Nothing in the build reads any of it. esbuild bundles the sources directly and never
type-checks, so `npm run typecheck` is a standalone gate — deliberately not wired into
`cdk synth`, so a synth cannot fail on a type error.

## What is checked, and what is not

The two match processors stay out: 2.3k lines of walking Valve's match JSON, and 210 of the
470 errors that turning this on initially produced. An annotation there is either `any` and
worthless, or a hand-written guess at a shape Valve owns — which is worse, because the
compiler stays green when the API drifts, and drifting APIs are how this repo actually
breaks. Their exported signatures are annotated, so callers are still checked.

Where the field set is small and shallow, the boundary is a named record of exactly the
fields we read rather than `any` — the two match-history responses, the OpenDota match and
player, and the two DynamoDB rows. These are assertions, not validation: nothing checks the
fields arrive, and the doc comments say so. What they buy is a typo becoming an error with
a suggestion attached instead of an `undefined` that reaches Discord. The cost is that
reading a new field means declaring it first.

The DynamoDB rows are the strongest case, because that schema is ours rather than Valve's,
so the type cannot go stale against an upstream we do not control.

Deeper responses stay `any`. `res.json()` returns `unknown`, so each call site casts once
rather than per field.

What *is* typed is what this repo constructs: the normalised token usage and message shapes,
the analysis the models are asked for, the cache interface the API clients depend on, and
the two flags that drive model fallback.

## What it caught

Beyond documentation drift:

- The cache read claimed to resolve a string and resolves `null` on both a miss and an
  expiry — every caller was reading a lie.
- An empty SSM parameter failed with a `TypeError` at module scope rather than naming the
  parameter.
- Two DynamoDB scans returned `undefined` when the table came back without `Items`, where
  the catch blocks beside them already returned `[]`.
- `formatBadge` survived a null argument only because `null / 10` is `0`.
- The Deadlock poller reads `error` off a result that is sometimes a skip. That one is
  correct — a bot match *should* advance the watermark without posting — but nothing said
  so, so the union is now written down.

Two false positives, neither a defect: a `response.status` read guarded by a `||`
short-circuit, and `URLSearchParams` rejecting numeric values it stringifies fine at
runtime. Both expressed rather than worked around.

## Bundle size

Grows 7.5KB across all seven bundles, from 99 bytes to 1.7KB each:

| bundle | before | after | delta |
|---|---|---|---|
| discordWebhookHandler | 4,052 | 4,151 | +99 (+2.4%) |
| noMansSky | 6,769 | 7,488 | +719 (+10.6%) |
| steamUpdates | 11,254 | 11,994 | +740 (+6.6%) |
| deadlockMatches | 25,485 | 26,690 | +1,205 (+4.7%) |
| deadlockAnalyst | 80,225 | 81,949 | +1,724 (+2.1%) |
| openDotaMatches | 135,275 | 136,560 | +1,285 (+1.0%) |
| dotaAnalyst | 2,660,909 | 2,662,624 | +1,715 (+0.06%) |

JSDoc is data rather than syntax, and with minify off esbuild keeps the blocks attached to
declarations it retains. Nothing at this scale is measurable at cold start, and turning
minify on would erase it.

## Second commit: self-review

Reviewed against the [ponytail](https://ponytail.dev/) ladder, which caught rung 2 in my
own diff — reaching for a new tool where the codebase already had one.

Conditional request fields were being set by mutation, which is what forced the
`Record<string, any>` annotations onto the object literals in the first place. The spread
form needs no annotation and was already in use eight lines away in the same file. Three
literals lose both the annotation and the mutation. Logging a caught error as `${err}` is
likewise the existing idiom in `lib/`; four sites had been rewritten to cast the binding
just to reach `.message`, which is more code and less information in the log.

Net −23 lines, and the bundle growth above is after this pass.

## Third commit: named shapes at the boundaries

Naming the shapes turned up two things the `any` had been hiding. The player lookup compared
a number `account_id` against a string key, so the loose `==` was load-bearing; it now
coerces with `Number()`, which is what both analysts already do. And `skill` is absent from
most OpenDota matches, so the lookup was indexing with `undefined` and landing on the same
empty string the table's own `0` entry holds; it now asks for `0`. Both were verified
identical across every input, including the absent and null cases.

## Fourth commit: a missing guard the types found

I tried putting the return type on `OpenDotaAPI.getMatch` rather than at the consumers, to
see whether the service is the better home for it. It is not — `getMatch` has three callers
reading divergent sets (8 fields in the poller, 2 in the analyst, 13 nested in the
processor), so a service-level type has to be their union, which slides into modelling
Valve's whole schema: the thing that goes stale silently. Types stay at the consumer, where
the claim is "this function reads these fields" rather than "OpenDota returns these fields".

The experiment did surface a real defect. `DotaAnalyst` dereferenced the result of
`players.find()` without a guard, where `OpenDotaMatches` guards it with a comment
explaining why the lookup can miss (`account_id` is null for private profiles) and
`DeadlockAnalyst` guards it and answers "Player not found in this match." The throw was
caught, so it was not silent — but the user got the generic error instead of the reason, and
the retry failed identically. The hero lookup beside it had the same shape, and is the same
crash already fixed once in the purchase log when dotaconstants trailed a Dota patch.

Typing the player array is what surfaced it and is what keeps it fixed: removing the guard
now fails the typecheck.

## Fifth commit: three live crashes, from a code review

The review pointed out that the `Record<number, X>` annotations added earlier in this branch
had made the compiler *agree* that a missing constants entry was impossible — so the gate
could not catch the exact bug the branch's own comments describe. That was right, and it was
hiding two reachable crashes:

Both pollers looked a hero up by id and dereferenced the result. The tables lag the games —
`dotaconstants` trails Valve by a release or two, and the Deadlock table is hand-maintained
here — so the first match played on a new hero throws. Neither throw is contained:
`OpenDotaMatches` builds every embed in a run before sending any, so one unknown hero drops
that run's notifications for *every* tracked player, and `DeadlockMatches.handler()` has no
try/catch at all. In both, `updateDB` never runs, so the watermark stays put and the next
poll throws on the same match indefinitely.

A quieter third: the Dota rank average fed unrecognised tiers into the mean as `indexOf`'s
`-1` rather than dropping them, dragging the estimate toward Herald and, with enough of
them, off the front of the table into `"undefined NaN"`. Deadlock's `averageBadge` already
filters these.

The fix is `noUncheckedIndexedAccess`. I had written it off as unusable against thousands of
game-constant lookups — but the two files holding most of them are the excluded processors,
so across what is checked it cost six call sites. It also makes the hand-written
`| undefined` annotations redundant, so those came back out: one flag, applied uniformly,
rather than something to remember on the next map.

## Verification

`npm run typecheck` clean, `prettier -c` clean, and every synthesised bundle still imports
and exports a usable `handler`. The rewritten request bodies were asserted byte-identical
to what the mutation produced, across every branch of both conditionals, and the rewritten
entity-decoding and CDATA paths byte-identical across their inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
