### PR TITLE
Analysts: Try gemini-3.7-flash before 3.6

### DIFF
--- a/lib/analysis.mjs
+++ b/lib/analysis.mjs
@@ -29,13 +29,9 @@ export const ANALYSIS_SCHEMA = {
   additionalProperties: false,
 };
 
-/**
- * Tried in order, best first, stepping down when a model is out of quota.
- *
- * The Gemini free tier caps each model separately -- 20 requests a day for
- * gemini-2.5-flash -- so a step down is a fresh allowance, not a share of one.
- */
+// The Gemini free tier caps each model separately, so this is the order to try.
 export const ANALYSIS_MODELS = [
+  "gemini-3.7-flash",
   "gemini-3.6-flash",
   "gemini-3.5-flash",
   "gemini-2.5-flash",

--- a/llm-evals/lib/pricing.mjs
+++ b/llm-evals/lib/pricing.mjs
@@ -12,6 +12,7 @@ const PRICING = {
   "gemini-3.5-flash": { input: 1.5, output: 9.0 },
   "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
   "gemini-3.6-flash": { input: 1.5, output: 7.5 },
+  "gemini-3.7-flash": { input: 0.75, output: 3.75 },
 };
 
 export function isPriced(model) {

--- a/llm-evals/lib/pricing.mjs
+++ b/llm-evals/lib/pricing.mjs
@@ -3,6 +3,7 @@ const PRICING = {
   "gpt-5": { input: 2.5, output: 10.0 },
   "gpt-5-mini": { input: 0.4, output: 1.6 },
   "gpt-5-nano": { input: 0.1, output: 0.4 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2 },
   "claude-opus-4-1": { input: 15.0, output: 75.0 },
   "claude-sonnet-4-5": { input: 3.0, output: 15.0 },
   "claude-haiku-4-5": { input: 0.8, output: 4.0 },


### PR DESCRIPTION
Puts `gemini-3.7-flash` at the front of the analyst fallback chain, and adds its price to
the eval harness.

Run through `llm-evals/generate-eval.mjs` on one Dota and one Deadlock match, same prompts
to both models:

| | latency | reasoning tokens | cost |
|---|---|---|---|
| `gemini-3.7-flash` | 10.8s, 11.9s | 1356, 595 | **$0.047** |
| `gemini-3.6-flash` | 25.5s, 13.7s | 2170, 1724 | $0.107 |

The analysis is the slowest stage of the handler, so the latency is most of the Lambda's
duration. 3.7 is half the published price of 3.6 on both input and output and spends fewer
reasoning tokens on top, so an analysis costs 44% of what 3.6 charges for it.

The thing worth checking, given #30: the output conforms to `ANALYSIS_SCHEMA` — all four
keys, no extras, all three lists arrays of strings. `additionalProperties: false` is accepted
via `response_json_schema`, so nothing changes in how the schema is sent.

On quality, the two models agree on every checkable fact in both analyses, and 3.7's
findings are the more specific — it cites item purchase timings and ability usage counts
where 3.6 stays general. Eval output is gitignored, so the blind ranking is a local step.

It is new enough to return 503 under load, which costs latency rather than answers: a 5xx is
retried and then steps down. That is why it goes in front of 3.6 rather than replacing it.

## Verification

`npm run typecheck` and `prettier -c` clean; all 7 bundles synthesise and import, with all
five models present in the emitted code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
