### PR TITLE
DotaAnalyst: Pick up OpenDota's new benchmark, role and damage-timeline fields

### DIFF
--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -797,7 +797,7 @@ BENCHMARKS
 - The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
 - Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
 - Write a percentile as "94th percentile", never as a bare percentage; "94%" in this analysis means a proportion, and the two are indistinguishable to the reader otherwise.
-- A "rank bracket" baseline holds the player's rank fixed, so those percentiles measure play; "all ranks" partly measures the rank they play at. Say which baseline a cited percentile came from.
+- A "rank bracket" baseline holds the player's rank fixed, so those percentiles measure play rather than matchmaking: cite one as "for their rank". Never name the baseline itself, and add no qualifier at all under "all ranks".
 
 HERO PICK ANALYSIS
 - Evaluate how the player's hero fits the team composition (initiation, wave clear, sustain, late-game scaling, etc.).

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -818,7 +818,7 @@ VISION & WARDING
 
 DAMAGE ANALYSIS
 - Use damageTaken breakdown to identify survivability issues and positioning problems.
-- Read heroDamageTimes against the teamfight timings to tell sustained fight presence from a single late spike.
+- teamfights already covers the logged fights, so read heroDamageTimes for what it cannot: damage accruing between them, which separates a player farming or split-pushing while their team fought from one who was simply absent.
 - Analyze combatAnalysis for ability/item usage efficiency and target prioritization.
 - Compare uses vs hits vs damage to assess accuracy and effectiveness.
 - Many abilities are legitimately used for farming/wave clear; don't criticize high uses without hero hits unless it's a key single-target ability or long-cooldown ultimate.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -887,7 +887,7 @@ TURBO MODE
 - This is a Turbo match. Raw economy and pacing stats (GPM, XPM, kills) are inflated by design; never judge them against normal Dota expectations.
 - Do not call raw GPM/XPM/kill rates "high/low" unless relative to this match (team averages, lane opponent, enemy heroes) or to the benchmarks percentiles.
 - The benchmarks percentiles are drawn from other Turbo matches on the same hero, so they are a valid measure of whether the player's pacing was good for Turbo.
-- Turbo's shared gold and loose lanes flatten the early farm order that role is derived from, so role is materially less reliable here; lean on the hero and the lane for the focus player's position, and do not state any player's position as settled fact.
+- Turbo compresses the farm gap between cores and supports that role is derived from, so corroborate it against the hero, the lane and the item build before leaning on it.
 - Popular item timings are based on professional matches and may not align with Turbo's accelerated pace; focus on item choices rather than timing criticism.
 `,
   18: `

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -185,8 +185,8 @@ function preparePlayers(match, focusPlayerId) {
 }
 
 // A zero ranks above everyone else who scored zero, so a hero that did no healing lands
-// in the 90th percentile for healing -- but a zero deaths_per_min is a real result. pct is
-// also absent or NaN when OpenDota has no sample, which would reach the prompt as "NaN".
+// in the 90th percentile for healing. Zero deaths_per_min is a real result, not an absent
+// metric. pct is absent or NaN when OpenDota has no sample, reaching the prompt as "NaN".
 function prepareBenchmarks(benchmarks) {
   const entries = Object.entries(benchmarks ?? {}).filter(
     ([name, benchmark]) =>
@@ -196,8 +196,8 @@ function prepareBenchmarks(benchmarks) {
 
   if (entries.length === 0) return undefined;
 
-  // pct_bracket arrives per metric, so falling back per metric would mix two baselines in
-  // one profile and break the shape comparison the prompt asks for.
+  // pct_bracket arrives per metric, so a per-metric fallback would mix two baselines in one
+  // profile and break the shape comparison the prompt asks for.
   const bracketed = entries.every(([, benchmark]) =>
     Number.isFinite(benchmark.pct_bracket),
   );

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -769,7 +769,7 @@ Return ONLY one JSON object that matches the schema exactly-no extra keys, no su
 MATCH DATA FORMAT
 - lastHitTimes, denyTimes, xpTime, goldTimes, heroDamageTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.). The final entry stops at the last whole minute and falls short of the matching total, so quote the total and read the array only for pacing
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
-- role: Estimated position 1-5 (1 = safe-lane carry, 5 = hard support), derived from early farm and lane. Carried by every player, and only on parsed matches
+- role: Estimated position 1-5 (1 = safe-lane carry, 5 = hard support), derived from each team's early farm order and lanes, not from the heroes. Carried by every player, and only on parsed matches. It is forced to spell 1-5 exactly once per team, so a lineup that did not play five distinct positions still gets five distinct labels
 - benchmarks.percentiles: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average, and higher is better for every metric including deaths_per_min, where a high percentile means the player died less than their peers
 - benchmarks.baseline: The comparison group behind those percentiles - "rank bracket" for players at this match's average rank, "all ranks" for every rank pooled
 
@@ -784,11 +784,12 @@ CONSTRAINTS
 - Comparisons only against values in this match (team averages, lane opponents, enemy cores).
 
 ROLE AWARENESS
-- Take role as the player's position when it is present; infer it from lane, hero, and early stats only when it is absent.
+- Take role as the opening read on a player's position, and infer it from lane, hero, and early stats when it is absent.
+- Where role contradicts the hero, lane and farm together, trust that evidence and say the player's position is unclear rather than asserting either one.
 - Evaluate performance relative to that role's responsibilities.
 - Do not penalize supports for low tower or hero damage, or cores for low warding.
 - Benchmarks are not role-adjusted; where the role differs from the hero's usual one, economy percentiles reflect that choice rather than execution.
-- Identify the lane opponent and the enemy cores from their role rather than from their heroes.
+- Identify the lane opponent and the enemy cores from role together with lane, since every player carries a role.
 - Frame strengths/weaknesses/recommendations according to role expectations.
 
 BENCHMARKS
@@ -886,6 +887,7 @@ TURBO MODE
 - This is a Turbo match. Raw economy and pacing stats (GPM, XPM, kills) are inflated by design; never judge them against normal Dota expectations.
 - Do not call raw GPM/XPM/kill rates "high/low" unless relative to this match (team averages, lane opponent, enemy heroes) or to the benchmarks percentiles.
 - The benchmarks percentiles are drawn from other Turbo matches on the same hero, so they are a valid measure of whether the player's pacing was good for Turbo.
+- Turbo's shared gold and loose lanes flatten the early farm order that role is derived from, so role is materially less reliable here; lean on the hero and the lane for the focus player's position, and do not state any player's position as settled fact.
 - Popular item timings are based on professional matches and may not align with Turbo's accelerated pace; focus on item choices rather than timing criticism.
 `,
   18: `

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -767,7 +767,7 @@ Refer to the player by the provided player name.
 Return ONLY one JSON object that matches the schema exactly-no extra keys, no surrounding text or code fences.
 
 MATCH DATA FORMAT
-- lastHitTimes, denyTimes, xpTime, goldTimes, heroDamageTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.). The final entry stops at the last whole minute and falls short of the matching total, so quote the total and read the array only for pacing
+- lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark on every player (index 0 = minute 0, index 10 = minute 10, etc.). heroDamageTimes is the same, on the focus player only. Every one of them stops at the last whole minute and so falls short of its matching total: quote the total, and read the array only for pacing
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
 - role: Estimated position 1-5 (1 = safe-lane carry, 5 = hard support), derived from each team's early farm order and lanes, not from the heroes. Carried by every player, and only on parsed matches. It is forced to spell 1-5 exactly once per team, so a lineup that did not play five distinct positions still gets five distinct labels
 - benchmarks.percentiles: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average, and higher is better for every metric including deaths_per_min, where a high percentile means the player died less than their peers
@@ -789,7 +789,7 @@ ROLE AWARENESS
 - Evaluate performance relative to that role's responsibilities.
 - Do not penalize supports for low tower or hero damage, or cores for low warding.
 - Benchmarks are not role-adjusted; where the role differs from the hero's usual one, economy percentiles reflect that choice rather than execution.
-- Identify the lane opponent and the enemy cores from role together with lane, since every player carries a role.
+- Identify the lane opponent and the enemy cores from role together with lane.
 - Frame strengths/weaknesses/recommendations according to role expectations.
 
 BENCHMARKS
@@ -818,7 +818,7 @@ VISION & WARDING
 
 DAMAGE ANALYSIS
 - Use damageTaken breakdown to identify survivability issues and positioning problems.
-- teamfights already covers the logged fights, so read heroDamageTimes for what it cannot: damage accruing between them, which separates a player farming or split-pushing while their team fought from one who was simply absent.
+- Read heroDamageTimes for the damage accruing between the fights teamfights logs: it separates a player farming or split-pushing while their team fought from one who was simply absent.
 - Analyze combatAnalysis for ability/item usage efficiency and target prioritization.
 - Compare uses vs hits vs damage to assess accuracy and effectiveness.
 - Many abilities are legitimately used for farming/wave clear; don't criticize high uses without hero hits unless it's a key single-target ability or long-cooldown ultimate.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -767,7 +767,7 @@ Refer to the player by the provided player name.
 Return ONLY one JSON object that matches the schema exactly-no extra keys, no surrounding text or code fences.
 
 MATCH DATA FORMAT
-- lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark on every player (index 0 = minute 0, index 10 = minute 10, etc.). heroDamageTimes is the same, on the focus player only. Every one of them stops at the last whole minute and so falls short of its matching total: quote the total, and read the array only for pacing
+- lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark on every player (index 0 = minute 0, index 10 = minute 10, etc.). heroDamageTimes is the same, on the focus player alone, and absent from matches parsed before OpenDota began emitting it. Every one of them stops at the last whole minute and so falls short of its matching total: quote the total, and read the array only for pacing
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
 - role: Estimated position 1-5 (1 = safe-lane carry, 5 = hard support), derived from each team's early farm order and lanes, not from the heroes. Carried by every player, and only on parsed matches. It is forced to spell 1-5 exactly once per team, so a lineup that did not play five distinct positions still gets five distinct labels
 - benchmarks.percentiles: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average, and higher is better for every metric including deaths_per_min, where a high percentile means the player died less than their peers
@@ -793,7 +793,7 @@ ROLE AWARENESS
 - Frame strengths/weaknesses/recommendations according to role expectations.
 
 BENCHMARKS
-- Percentiles compare the player against everyone on that hero regardless of role, so read the profile's shape rather than its overall level.
+- Percentiles are not adjusted for role, so read the profile's shape rather than its overall level.
 - A roughly uniform shift across the economy percentiles (gold, xp, last hits) usually means the player took a different role than the hero's norm; treat that as a role choice, not as good or bad play.
 - The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
 - Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
@@ -818,7 +818,7 @@ VISION & WARDING
 
 DAMAGE ANALYSIS
 - Use damageTaken breakdown to identify survivability issues and positioning problems.
-- Read heroDamageTimes for the damage accruing between the fights teamfights logs: it separates a player farming or split-pushing while their team fought from one who was simply absent.
+- Compare heroDamageTimes against the teamfight windows: damage accruing outside them separates a player farming or split-pushing while their team fought from one who was simply absent.
 - Analyze combatAnalysis for ability/item usage efficiency and target prioritization.
 - Compare uses vs hits vs damage to assess accuracy and effectiveness.
 - Many abilities are legitimately used for farming/wave clear; don't criticize high uses without hero hits unless it's a key single-target ability or long-cooldown ultimate.

--- a/lib/DotaMatchProcessor.mjs
+++ b/lib/DotaMatchProcessor.mjs
@@ -124,6 +124,7 @@ function preparePlayers(match, focusPlayerId) {
       stunsSeconds: player.stuns,
       abandoned: player.leaver_status > 1,
       lane: LANE_NAMES[player.lane_role],
+      role: player.position_est,
       lastHitTimes: player.lh_t,
       denyTimes: player.dn_t,
       xpTime: player.xp_t,
@@ -170,6 +171,7 @@ function preparePlayers(match, focusPlayerId) {
       },
       courierKills: player.courier_kills,
       campsStacked: player.camps_stacked,
+      heroDamageTimes: player.hero_damage_t,
       combatAnalysis: processCombatAnalysis(player),
       chat: match.chat
         .filter(
@@ -177,21 +179,38 @@ function preparePlayers(match, focusPlayerId) {
             msg.player_slot === player.player_slot && msg.type === "chat",
         )
         .map((msg) => ({ time: msg.time, message: msg.key })),
-      ...(Object.keys(benchmarks).length > 0 ? { benchmarks } : {}),
+      ...(benchmarks ? { benchmarks } : {}),
     };
   });
 }
 
 // A zero ranks above everyone else who scored zero, so a hero that did no healing lands
-// in the 90th percentile for healing. pct is also absent or NaN when OpenDota has no
-// sample, which would reach the prompt as the string "NaN".
+// in the 90th percentile for healing -- but a zero deaths_per_min is a real result. pct is
+// also absent or NaN when OpenDota has no sample, which would reach the prompt as "NaN".
 function prepareBenchmarks(benchmarks) {
-  return Object.entries(benchmarks ?? {}).reduce((acc, [name, benchmark]) => {
-    if (Number.isFinite(benchmark.pct) && benchmark.raw > 0) {
-      acc[name] = (benchmark.pct * 100).toFixed(2);
-    }
-    return acc;
-  }, {});
+  const entries = Object.entries(benchmarks ?? {}).filter(
+    ([name, benchmark]) =>
+      Number.isFinite(benchmark.pct) &&
+      (benchmark.raw > 0 || name === "deaths_per_min"),
+  );
+
+  if (entries.length === 0) return undefined;
+
+  // pct_bracket arrives per metric, so falling back per metric would mix two baselines in
+  // one profile and break the shape comparison the prompt asks for.
+  const bracketed = entries.every(([, benchmark]) =>
+    Number.isFinite(benchmark.pct_bracket),
+  );
+
+  return {
+    baseline: bracketed ? "rank bracket" : "all ranks",
+    percentiles: Object.fromEntries(
+      entries.map(([name, benchmark]) => [
+        name,
+        ((bracketed ? benchmark.pct_bracket : benchmark.pct) * 100).toFixed(2),
+      ]),
+    ),
+  };
 }
 
 function heroByRaw(raw) {
@@ -748,9 +767,11 @@ Refer to the player by the provided player name.
 Return ONLY one JSON object that matches the schema exactly-no extra keys, no surrounding text or code fences.
 
 MATCH DATA FORMAT
-- lastHitTimes, denyTimes, xpTime, goldTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.)
+- lastHitTimes, denyTimes, xpTime, goldTimes, heroDamageTimes: Arrays of cumulative values at each minute mark (index 0 = minute 0, index 10 = minute 10, etc.). The final entry stops at the last whole minute and falls short of the matching total, so quote the total and read the array only for pacing
 - radiantGoldAdvantage, radiantXpAdvantage: Arrays showing advantage over time at each minute
-- benchmarks: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average; higher is better for every metric except deaths_per_min, where higher means the player died more than their peers
+- role: Estimated position 1-5 (1 = safe-lane carry, 5 = hard support), derived from early farm and lane. Carried by every player, and only on parsed matches
+- benchmarks.percentiles: Percentile rank (0-100) of the focus player against other recent players on the same hero. Turbo matches are ranked against other Turbo matches; every other mode shares one pool, so in an unusual mode the comparison group is mostly ordinary matches. 50 is average, and higher is better for every metric including deaths_per_min, where a high percentile means the player died less than their peers
+- benchmarks.baseline: The comparison group behind those percentiles - "rank bracket" for players at this match's average rank, "all ranks" for every rank pooled
 
 CONSTRAINTS
 - Use only data explicitly present in JSON; never invent, infer, or speculate on missing values.
@@ -763,10 +784,11 @@ CONSTRAINTS
 - Comparisons only against values in this match (team averages, lane opponents, enemy cores).
 
 ROLE AWARENESS
-- Infer the player's role (pos 1-5) from lane, hero, and early stats.
+- Take role as the player's position when it is present; infer it from lane, hero, and early stats only when it is absent.
 - Evaluate performance relative to that role's responsibilities.
 - Do not penalize supports for low tower or hero damage, or cores for low warding.
-- Benchmarks are not role-adjusted; where the inferred role differs from the hero's usual one, economy percentiles reflect that choice rather than execution.
+- Benchmarks are not role-adjusted; where the role differs from the hero's usual one, economy percentiles reflect that choice rather than execution.
+- Identify the lane opponent and the enemy cores from their role rather than from their heroes.
 - Frame strengths/weaknesses/recommendations according to role expectations.
 
 BENCHMARKS
@@ -775,6 +797,7 @@ BENCHMARKS
 - The signal is divergence within the profile: call out a metric that stands apart from that player's other percentiles.
 - Cite the percentile when a strength or weakness rests on a metric that has one. Do not deliver an overall verdict on the benchmarks.
 - Write a percentile as "94th percentile", never as a bare percentage; "94%" in this analysis means a proportion, and the two are indistinguishable to the reader otherwise.
+- A "rank bracket" baseline holds the player's rank fixed, so those percentiles measure play; "all ranks" partly measures the rank they play at. Say which baseline a cited percentile came from.
 
 HERO PICK ANALYSIS
 - Evaluate how the player's hero fits the team composition (initiation, wave clear, sustain, late-game scaling, etc.).
@@ -794,6 +817,7 @@ VISION & WARDING
 
 DAMAGE ANALYSIS
 - Use damageTaken breakdown to identify survivability issues and positioning problems.
+- Read heroDamageTimes against the teamfight timings to tell sustained fight presence from a single late spike.
 - Analyze combatAnalysis for ability/item usage efficiency and target prioritization.
 - Compare uses vs hits vs damage to assess accuracy and effectiveness.
 - Many abilities are legitimately used for farming/wave clear; don't criticize high uses without hero hits unless it's a key single-target ability or long-cooldown ultimate.


### PR DESCRIPTION
Four upstream OpenDota changes landed recently. All four are merged and verified live against `api.opendota.com`.

## The bug that motivated this

[odota/core#2978](https://github.com/odota/core/pull/2978) inverted the `deaths_per_min` percentile so that higher is better, matching every other benchmark. The system prompt still told the model the opposite, so the analyst was reading death commentary backwards — a deathless player now returns `pct: 0.98`, which the prompt described as having died far more than their peers.

The same metric was also being dropped entirely for a deathless game: the `raw > 0` filter exists because a zero ranks above everyone else who scored zero (a hero that did no healing lands in the 90th percentile for healing), but zero deaths is a real result rather than a metric that did not apply. `deaths_per_min` is now exempt from that filter.

## What each PR contributes

**[#2970](https://github.com/odota/core/pull/2970) — `deaths_per_min`, `assists_per_min`, `denies_per_min` benchmarks.** Already reaching the prompt, since the benchmarks are passed through by key. No change beyond the two fixes above.

**[#2974](https://github.com/odota/core/pull/2974) — `position_est`.** Surfaced as `role` on every player, replacing role inference the prompt previously asked the model to perform. Because it covers both teams, the analyst can identify the lane opponent and the enemy cores rather than guessing from heroes. The inference wording stays as the fallback, since the field is absent on unparsed matches.

**[#2979](https://github.com/odota/core/pull/2979) — `pct_bracket`.** Percentiles restricted to the match's own rank bracket, which measures how a player played rather than which rank they play at. OpenDota populates it per metric, so the swap is all-or-nothing: mixing baselines across metrics would break the shape comparison the prompt asks the model to make. The benchmarks now carry a `baseline` naming the comparison group. Not populated for turbo.

**[#2968](https://github.com/odota/core/pull/2968) — per-minute series.** Only `hero_damage_t` is taken, as `heroDamageTimes` on the focus player. `hero_healing_t` stays at zero for about two thirds of players and `camps_stacked_t` adds little over the total, so neither is worth ~45 numbers of prompt. Present only on matches parsed since the upstream change deployed.

Every cumulative array stops at the last whole minute and falls short of its matching total — 26,391 against a `hero_damage` of 33,537 on one match checked — so the prompt tells the model to quote the total and read the array only for pacing.

## What testing changed

Each change was run A/B through the analyst, three times per variant on a pinned model. Three findings came back and are folded into the later commits:

- **The baseline leaked into user-facing text.** Instructing the model to say which baseline it cited produced "35th percentile on the all ranks baseline" in every run. Since the qualifier only carries meaning for the rank-matched case, the prompt now asks for "for their rank" there and no qualifier otherwise.
- **The estimated position is treated as evidence, not fact.** The estimator always spells 1-5 exactly once per team, so a lineup that did not play five distinct positions still gets five distinct labels. The prompt now says to trust hero, lane and farm where they contradict it. A three-way run — no field, field unhedged, field hedged — found the analyst reaching the same correct read in all three, so the hedge costs nothing when the evidence agrees.
- **The damage timeline was pointed at the wrong question.** It originally asked for fight presence, which the per-fight damage already in `teamfights` answers better, and the model ignored it in every run. It now asks for the damage accruing between logged fights, which is the part `teamfights` cannot cover.

Verified across three matches: the recovered death benchmark is cited in every post-change run of a deathless game (98th percentile, absent entirely before), `pct_bracket` reads cleanly with no jargon leaks, and `role` matches the model's own inference. `heroDamageTimes` drew no citations under the original wording; the rewritten instruction is not yet re-tested.

`npm run typecheck` and `prettier -c` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
